### PR TITLE
Allow local versions of the API/UI to be run

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ You will be able to log into the application at http://localhost:3000 with the f
 
 There is also a usable CRN: `X320741`
 
+##### Running local instances of the UI or API
+
+If you need to run local instances of either the UI or API (rather than serving them from the latest Docker images), you can run add `--local-ui` or `--local-api` flags to the `start` command like so:
+
+```bash
+ap-tools server start --local-ui
+```
+
+```bash
+ap-tools server start --local-api
+```
+
+```bash
+ap-tools server start --local-ui --local-api
+```
+
+Note: For this to work, you must have the path to your API / UI repos set as environment variables (e.g in your `.bashrc` file), i.e:
+
+```bash
+export APPROVED_PREMISES_UI_PATH=/full/path/to/your/repo
+export APPROVED_PREMISES_API_PATH=/full/path/to/your/repo
+```
+
 #### Stop Server
 
 ```bash

--- a/bin/server
+++ b/bin/server
@@ -14,9 +14,9 @@ else
 fi
 
 if [ "$command" = "start" ]; then
-  "$(dirname "$0")/start-server" "$*"
+  "$(dirname "$0")/start-server" "$@"
 elif [ "$command" = "stop" ]; then
-  "$(dirname "$0")/stop-server" "$*"
+  "$(dirname "$0")/stop-server"
 else
   echo "Unknown command $command"
   exit 1

--- a/bin/start-server
+++ b/bin/start-server
@@ -1,7 +1,38 @@
 #!/bin/sh
 
+args=""
+
+while [ "$1" != "" ];
+do
+   case $1 in
+    --local-ui)
+        if [ -z "${APPROVED_PREMISES_UI_PATH}" ]; then
+          echo "Path to local UI not found, please ensure you have set the APPROVED_PREMISES_UI_PATH environment variable and try again"
+          exit 1
+        fi
+        args="$args --local-ui"
+        ;;
+    --local-api)
+        if [ -z "${APPROVED_PREMISES_API_PATH}" ]; then
+          echo "Path to local API not found, please ensure you have set the APPROVED_PREMISES_API_PATH environment variable and try again"
+          exit 1
+        fi
+        args="$args --local-api"
+        ;;
+  esac
+  shift
+done
+
 echo "Starting the Approved Premises Stack. This might take a moment. Logs available at http://localhost:10350"
-tilt up -f "$(dirname "$0")/../tiltfile" > /dev/null 2>&1 &
+
+cmd="tilt up -f $(dirname "$0")/../tiltfile"
+
+if [ ${#args} -ge 0 ]; then
+  cmd="$cmd -- $args"
+fi
+
+$cmd > /dev/null 2>&1 &
+
 until lsof -i:3000 > /dev/null; do
   printf '.'
   sleep 2

--- a/tiltfile
+++ b/tiltfile
@@ -1,5 +1,13 @@
 docker_compose("./docker-compose.yml")
 
+config.define_bool("local-api")
+config.define_bool("local-ui")
+
+cfg = config.parse()
+
+local_api = cfg.get("local-api", False)
+local_ui = cfg.get("local-ui", False)
+
 resources = [
     "api",
     "frontend",
@@ -11,9 +19,42 @@ resources = [
     "prison-api",
     "redis",
     "hmpps-auth",
-    "redis",
     "community-api",
 ]
+
+if local_api:
+    resources.remove("api")
+    local_resource(
+        "local_api",
+        serve_cmd="./gradlew bootRunLocal",
+        resource_deps=["database", "redis", "hmpps-auth"],
+        serve_dir=os.getenv("APPROVED_PREMISES_API_PATH"),
+        readiness_probe=probe(
+            period_secs=15, http_get=http_get_action(port=8080, path="/health")
+        ),
+    )
+    resources.append("local_api")
+
+if local_ui:
+    resources.remove("frontend")
+    local_resource(
+        "local_ui",
+        cmd="npm install",
+        serve_cmd="npm start",
+        serve_dir=os.getenv("APPROVED_PREMISES_UI_PATH"),
+        dir=os.getenv("APPROVED_PREMISES_UI_PATH"),
+        resource_deps=["hmpps-auth"],
+        readiness_probe=probe(
+            period_secs=15, http_get=http_get_action(port=3000, path="/health")
+        ),
+        serve_env={
+            "APPROVED_PREMISES_API_URL": "http://localhost:8080",
+            "HMPPS_AUTH_URL": "http://localhost:9091/auth",
+            "HMPPS_AUTH_EXTERNAL_URL": "http://localhost:9091/auth",
+            "TOKEN_VERIFICATION_API_URL": "http://localhost:9091/verification",
+        },
+    )
+    resources.append("local_ui")
 
 config.clear_enabled_resources()
 config.set_enabled_resources(resources)


### PR DESCRIPTION
This adds `--local-ui` and `--local-api` flags to the `server start` command, which enabled the local versions of the app to be run, with the help of Tilt’s `local_resource` function. This requires environment variables to be set so tilt knows where the repos are, but this seems to work!