### PR TITLE
Fix for ARM processors

### DIFF
--- a/bin/start-server
+++ b/bin/start-server
@@ -33,7 +33,7 @@ fi
 
 $cmd > /dev/null 2>&1 &
 
-until lsof -i:3000 > /dev/null; do
+until lsof -i:9590 > /dev/null; do
   printf '.'
   sleep 2
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,6 @@ services:
       - SPRING_REDIS_PORT=6379
     ports:
       - 8080:8080
-    depends_on:
-      database:
-        condition: service_healthy
-      hmpps-auth:
-        condition: service_healthy
 
   frontend:
     image: quay.io/hmpps/hmpps-approved-premises-ui:latest
@@ -45,9 +40,6 @@ services:
     ports:
       - 3000:3000
     entrypoint: "node dist/server.js | bunyan"
-    depends_on:
-      hmpps-auth:
-        condition: service_healthy
 
   database:
     image: "postgres"
@@ -85,17 +77,12 @@ services:
       - DELIUS_CLIENT_CLIENT-ID=delius-auth-api-client
       - DELIUS_CLIENT_CLIENT-SECRET=delius-auth-api-client
       - LOGGING_LEVEL_UK_GOV_JUSTICE=debug
-    depends_on:
-      community-api:
-        condition: service_healthy
 
   community-api:
     image: quay.io/hmpps/community-api:latest
     container_name: community-api
     ports:
       - "9590:8080"
-    healthcheck:
-      test: ["CMD", "wget", "-nv", "-t1", "--spider", "http://localhost:8080/api/health"]
     volumes:
       - ./seed/community-api:/seed
     environment:

--- a/tiltfile
+++ b/tiltfile
@@ -19,7 +19,6 @@ resources = [
     "prison-api",
     "redis",
     "hmpps-auth",
-    "community-api",
 ]
 
 if local_api:


### PR DESCRIPTION
Tilt was not working on my MBP - probably due to the emulation load the [community-api](https://github.com/ministryofjustice/community-api/) was putting on the machine.
Thanks to the work of @pezholio [here](https://github.com/ministryofjustice/community-api/pull/732) a multiplatform version of the community-api was created.
However the `ap-tools server start` script was still failing due to the dependencies between the services as mentioned in [this issue comment](https://github.com/tilt-dev/tilt/issues/2210#issuecomment-532957058). With these removed and with some patience whilst waiting for the community-api to come up, the issue is resolved.
