### PR TITLE
Poll Community API health endpoint for readiness

### DIFF
--- a/bin/start-server
+++ b/bin/start-server
@@ -33,7 +33,7 @@ fi
 
 $cmd > /dev/null 2>&1 &
 
-until lsof -i:9590 > /dev/null; do
+until curl http://localhost:9590/api/health > /dev/null 2>&1; do
   printf '.'
   sleep 2
 done


### PR DESCRIPTION
The Community API is the last thing that comes up when bringing the stack up. Before, we were just checking the port, which shows as up as soon as the container comes up. What we’re really interested in is if the HTTP server is up, so let’s poll the health endpoint instead.