### PR TITLE
Explicitly set prison-api version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       - ./wiremock:/home/wiremock
 
   prison-api:
-    image: quay.io/hmpps/prison-api:latest
+    image: quay.io/hmpps/prison-api:2022-10-24.14293.29a4440
     container_name: prison-api
     ports:
       - "9570:8080"


### PR DESCRIPTION
Issue with newer tags where some database tables in HSQLDB cannot be read by the application