### PR TITLE
Wiremock stubs for AP-to-OASys API

### DIFF
--- a/wiremock/mappings/ApAndOAsys_GetRiskManagementPlan.json
+++ b/wiremock/mappings/ApAndOAsys_GetRiskManagementPlan.json
@@ -1,0 +1,33 @@
+{
+  "id": "01794bde-9568-4795-b4d9-5e09105f3ba0",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/risk-management-plan/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentPk": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "risk-management-plan": {
+        "furtherConsiderations": "[RM28] Mr Smith is currently on remand awaiting sentence",
+        "additionalComments": "[RM35] Placeholder content for additional comments",
+        "contingencyPlans": "[RM34] Discuss any concerns with line manager/SPO Increase frequency of reporting Bring forward MAPPA/Consider Level 2 MAPPA professionals meetings  considered if MAPPA not applicable. Consider referral to Approved Premises Consider motivational interviewing/engagement officer.  Joint interview with police OM or other relevant agencies? To raise concerns Referral to substance misues worker for additional support. Warning letters to be employed Recall/Breach if risk not manageable.",
+        "victimSafetyPlanning": "[RM33] Undertake sentence planning with OS within 8 or 16 weeks of sentence carats - continue to work with Mr Smith and refer for relevant programmes during any prison sentence imposed. DIP supervise DRR is imposed or provide support post release if conditions/requirements to manage the specific risks.",
+        "interventionsAndTreatment": "[RM32] Requires referral to community drug DIP upon  release. To link in with employment/training resources such as College and ETEO. Completion of victim empathy module via 1-1 supervision to build upon awareness of impact of offending.   Level setting to be undertaken by Senior Probation Officer and OMU. Multi Agency Public Protection Panel to be convened if level 2 either at start of supervision or 6 months prior to release",
+        "monitoringAndControl": "[RM31] State they will have secure accommodation for Mr Smith  and partner on release, although she too is subject to a DRR at present. Supportive wider family.  Has completed previously Short Duration programme and attended one of the support sessions .  Engaged with CARATS in custody.  Complied with voluntary drug tests in custody. Some motivation to desist from alcohol/drug use in the future, this needs to be encouraged with use of community resources. Completed drug and heroin awareness programmes in custody.",
+        "supervision": "[RM30] Probation Officer, Education training and employment Officer, Prison Offender Supervisor",
+        "keyInformationAboutCurrentSituation": "[RM28.1] Currently on remand at HMP Wandsworth - Management of case under MAPPA - level not yet set."
+      }
+    }
+  }
+}

--- a/wiremock/mappings/ApAndOAsys_GetRiskManagementPlan.json
+++ b/wiremock/mappings/ApAndOAsys_GetRiskManagementPlan.json
@@ -10,11 +10,11 @@
     },
     "status": 200,
     "jsonBody": {
-      "assessmentPk": 1310103,
+      "assessmentId": 1310103,
       "assessmentType": "LAYER3",
       "dateCompleted": null,
       "assessorSignedDate": null,
-      "initiationDate": "2022-11-02T15:17:29",
+      "initiationDate": "2022-11-02T15:17:29Z",
       "assessmentStatus": "OPEN",
       "superStatus": "WIP",
       "limitedAccessOffender": false,

--- a/wiremock/mappings/ApAndOasys_GetOffenceAnalysis.json
+++ b/wiremock/mappings/ApAndOasys_GetOffenceAnalysis.json
@@ -10,11 +10,11 @@
     },
     "status": 200,
     "jsonBody": {
-      "assessmentPk": 1310103,
+      "assessmentId": 1310103,
       "assessmentType": "LAYER3",
       "dateCompleted": null,
       "assessorSignedDate": null,
-      "initiationDate": "2022-11-02T15:17:29",
+      "initiationDate": "2022-11-02T15:17:29Z",
       "assessmentStatus": "OPEN",
       "superStatus": "WIP",
       "limitedAccessOffender": false,

--- a/wiremock/mappings/ApAndOasys_GetOffenceAnalysis.json
+++ b/wiremock/mappings/ApAndOasys_GetOffenceAnalysis.json
@@ -1,0 +1,34 @@
+{
+  "id": "f5f0e36b-84a5-4169-92f3-3719cec200f4",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offence-details/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentPk": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "offenceDetails": {
+        "offenceAnalysis": "[2.1] Mr Smith appeared before Newcastle Crown Court 16/09/2021 where he pleaded guilty to Wounding and other acts endangering life...",
+        "othersInvolved": "[2.7.3] Mr Smith had some associates at his house at the time of the index offence, the total number is unknown...",
+        "issueContributingToRisk": "[2.98] The index offence is assessed as harm related and there is an identifiable victim Ms Black...",
+        "offenceMotivation": "[2.8.3] Mr Smith states that he was angry, and became aggressive towards Ms Black because...",
+        "victimImpact": "[2.5] Ms Black attended Newtree hospital at 22:40 hours on 01/03/21 with injuries to her face and body that they were...",
+        "victimPerpetratorRel": "[2.4.2] Ms Joan Black, ex-partner of Mr Smith ",
+        "victimInfo": "[2.4.1] There is an element of vulnerability as Ms Black experience years of domestic abuse...",
+        "patternOffending": "[2.12] Mr Smith has 11 previous convictions from 22 offences. His criminal history includes...",
+        "acceptsResponsibility": "[2.11.t] Mr Smith states that he takes full responsibility for his actions and seems remorseful..."
+      }
+    }
+  }
+}

--- a/wiremock/mappings/ApAndOasys_GetRiskContributors.json
+++ b/wiremock/mappings/ApAndOasys_GetRiskContributors.json
@@ -10,11 +10,11 @@
     },
     "status": 200,
     "jsonBody": {
-      "assessmentPk": 1310103,
+      "assessmentId": 1310103,
       "assessmentType": "LAYER3",
       "dateCompleted": null,
       "assessorSignedDate": null,
-      "initiationDate": "2022-11-02T15:17:29",
+      "initiationDate": "2022-11-02T15:17:29Z",
       "assessmentStatus": "OPEN",
       "superStatus": "WIP",
       "limitedAccessOffender": false,

--- a/wiremock/mappings/ApAndOasys_GetRiskContributors.json
+++ b/wiremock/mappings/ApAndOasys_GetRiskContributors.json
@@ -1,0 +1,35 @@
+{
+  "id": "2d8c6b9a-78fd-4ef6-9a2b-11794061dc08",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/needs-details/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentPk": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "needs": {
+        "emotionalIssuesDetails": "[10.9] Mr Smith told me that he was untroubled by mental health difficulties and had no history of self harm or suicidal thoughts",
+        "drugIssuesDetails": "[8.9] Mr Smith told me that he had experimented with many drugs throughout his teens. He first used heroin when he was 15 years old but states he did not become addicted until he was 18. He said that he had remained in the grip of this addiction since that time, with some periods of abstinence.  He recalled that at its peak, his heroin addiction was such that he was using up to 1/8 of an ounce daily, supplementing his own use by selling this substance. The court will be aware that he has previously served two lengthy prison sentences for offences of supplying Class A drugs. Mr Smith has administered heroin intravenously",
+        "alcoholIssuesDetails": "[9.9] Mr Smith told me that he rarely consumes alcohol and has not had any problems associated with excessive drinking in years.  He admitted that he occasionally used to drink to excess as a teenager, sometimes becoming involved in fights as a result. He was convicted of section 20 wounding in 1988, when he was 17, and he recalled that this incident had been partially triggered by alcohol.  He has a more recent conviction for Affray in 2004 which occurred in a put but Mr Smith says he had only had one pint, on that occasion having been on his way home from work.",
+        "lifestyleIssuesDetails": "[7.9] Mr Smith has clearly had issues concerning the company he keeps, in that his involvement in the drug culture has at times been entrenched. For example, when he was selling drugs in order to supplement his own addiction.   Spending time with others who are drug users will undoubtedly increase the risk he poses of involvement in criminal activity, as well as undermining his efforts to become drug free, as evidenced by the circumstances of the current offence. However, as referred to earlier, he said that his family do not approve of drug use and represent an element of stability in his life. He is forty years of age now and is under no illusions regarding the impact that certain associates will have on his stated motivation to change.",
+        "relationshipIssuesDetails": "[6.9] Mr Smith described his family as travellers.  He said that they were very supportive of him, although they had at times found it difficult to accept his involvement with drugs.  He has three children, aged 19, 16 and 14 from a previous relationship.  He told me that his eldest daughter is currently resident abroad but he has regular contact with his younger children.  Mr Smith said that he and his girlfriend have been together for approximately one year. She, too, has issues with drugs and is currently subject to a DRR.  He spoke of their shared motivation to stop using drugs, and commented that she is currently making significant progress.",
+        "financeIssuesDetails": "[5.9] Mr Smith was in receipt of Job Seekers Allowance prior to his current remand in custody. He commented that he was generally good at managing his finances and said that he had no significant debts. However, in the past he has clearly offended regularly in order to fund his addition to drugs.  In addition, there was a financial element to the current matter, in that he believed he was being taken advantage of.",
+        "educationTrainingEmploymentIssuesDetails": "[4.9] He said that he has since learnt to read and write during periods of custody and an initial assessment of his basic skills indeed indicates that he has adequate levels of literacy and numeracy ability. He said that in the past he had generally worked on an intermittent, ad hoc basis; including employment as a labourer, carpenter and road worker. Mr Smith told me that he was last employed in 2004.  he spoke of wanting to secure suitable employment although he knows that he will first need to fully address his drug issues.",
+        "accommodationIssuesDetails": "[3.9] Mr Smith told me that he was renting a room in a shared house, prior to his current remand. He said that this accommodation had been facilitated by the One Tree Housing Association. He intends to move in with his girlfriend on his release.",
+        "attitudeIssuesDetails": "[12.9] During interview, Mr Smith referred to being motivated to alter his lifestyle significantly and address his drug use. However, departmental records indicate that in the past he has expressed similar sentiments which have ultimately failed, resulting in further criminal activity. Therefore, he will need to be tenacious in sustaining his stated levels of motivation, possibly provide his absolute assurances to the court regarding his intentions in the event that he regains his liberty if he is to offered any further opportunity to avoid a prison sentence on this occasion.",
+        "thinkingBehaviouralIssuesDetails": "[11.9] The circumstances of the current offence suggest that Mr Smith acted in an impulsive, ill considered and aggressive manner, paying scant regard to the consequences of his actions. He did, to his credit, acknowledges that he could and should have dealt with the situation in a more sensible and measured way. However, he did have some difficulty identifying how this could have been achieved.  Clearly, his involvement with illicit substances was a huge factor in his motivation for this offence:  the need to buy drugs and possibly the sub culture of criminality which permeates such transactions will have influenced his decision to resort to violence in order to vent his sense of grievance regarding the victim in this case.  I say this because it would appear that this..."
+      }
+    }
+  }
+}

--- a/wiremock/mappings/ApAndOasys_GetRoshSummary.json
+++ b/wiremock/mappings/ApAndOasys_GetRoshSummary.json
@@ -10,11 +10,11 @@
     },
     "status": 200,
     "jsonBody": {
-      "assessmentPk": 1310103,
+      "assessmentId": 1310103,
       "assessmentType": "LAYER3",
       "dateCompleted": null,
       "assessorSignedDate": null,
-      "initiationDate": "2022-11-02T15:17:29",
+      "initiationDate": "2022-11-02T15:17:29Z",
       "assessmentStatus": "OPEN",
       "superStatus": "WIP",
       "limitedAccessOffender": false,

--- a/wiremock/mappings/ApAndOasys_GetRoshSummary.json
+++ b/wiremock/mappings/ApAndOasys_GetRoshSummary.json
@@ -1,0 +1,30 @@
+{
+  "id": "1112984a-9435-4a75-b0e1-30c6b4caf6d6",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/rosh-summary/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentPk": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "rosh-summary": {
+        "whoAtRisk": "[R10.1] IN CUSTODY\n\nKNOWN ADULTS:\nSuch as Ms Elaine Underhill and any of the victims of the index offence if they are placed close to Mr Smith cell.\n\nCHILDREN:\nSimon Smith, Roger Smith, Lindy Smith",
+        "natureOfRisk": "[R10.2] IN CUSTODY:\n\nKNOWN ADULTS:\nIntimidation, threats of violence, use of weapons or boiling water, physical education and violent assault, long term psychological impact as a result of Mr Smith violent behaviour. This harm may be cause in the course of physical altercation due to seeking revenge or holding grudges...",
+        "riskGreatest": "[R10.3] STATIC RISK FACTORS:\n\nMr Smith gender - At the time of the offence, Mr Smith was 35 years old and considered to be in the higher risk group.\n\nSTABLE DYNAMIC RISK FACTORS:\nThinking and behaviour - limited ability to manage mood or emotions poor impulse control. Mr Smith demonstrated cognitive deficit in committing the index offences and this still remains a concern...",
+        "riskIncreaseLikelyTo":  "[R10.4] CIRCUMSTANCES:\nA lack of stable accommodation\nunemployment\nnon constructive use of time\nbreakdown of family support\nbeing unable to access benefits\n\nUNDERLYING FACTORS:\npro criminal attitudes supporting commission of crime...",
+        "riskReductionLikelyTo": "[R10.5] Engage with Mental Health Services in prison and in the community.\nMaintain emotional stability.\nAbstain from alcohol.\nAbstain from illegal drugs.\nRegular testing for alcohol and drug use, in prison and on Licence.\nMaintain stable accommodation..."
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is the first in several OASys endpoint stubs which are needed to enable our UI work to progress whilst we wait for the upstream APIs to come online.

These stubbed endpoints will be called at the new `approved-premises-and-oasys` API being built by integrations as a facade over the (also) new Oracle ORDS endpoints being built by the Capita team. e.g.

```
GET https://approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk/offence-details/{crn}
```

See https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/216 for our initial design for how these responses will be enhanced by our API to make them clearer for implementation at the UI.