### PR TITLE
Add wiremock for new RoSH risk ratings (R10.6) endpoint

### DIFF
--- a/wiremock/mappings/ApAndOasys_GetRoshRiskRatings.json
+++ b/wiremock/mappings/ApAndOasys_GetRoshRiskRatings.json
@@ -1,0 +1,34 @@
+{
+  "id": "3945dfc8-a31b-4877-9eeb-5ae391e8d6e1",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/rosh/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentId": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "rosh": {
+        "riskChildrenCommunity": "Medium",
+        "riskPublicCommunity": "High",
+        "riskKnownAdultCommunity": "High",
+        "riskStaffCommunity": "Low",
+        "riskChildrenCustody": "Low",
+        "riskPublicCustody": "Low",
+        "riskKnownAdultCustody": "Low",
+        "riskStaffCustody": "Low",
+        "riskPrisonersCustody": "Low"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The data from this endpoint is used to build the risk widget we show in the sidebar.

We've been getting these ratings from ARN (`/risks/crn/$crn`) in the ARN client's `getRoshRisks` function via the `OffenderService`

https://github.com/ministryofjustice/approved-premises-api/blob/f089b31a34e4bf734657f16491f6207a57dbeb38/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt#L277-L292

So that we are sure to be using data from the same OASys assessment throughout the AP service we need to refactor this code to use the new `ap-and-aoays/rosh` endpoint which provides these ratings from the latest layer 3 assessment regardless of its status -- rather from the latest *complete* assessment, as is the case with ARN.