### PR TITLE
Add stub for AP Delius Context Managing Teams endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - SERVICES_PRISONS-API_BASE-URL=http://prison-api:8080
       - SERVICES_CASE-NOTES_BASE-URL=http://wiremock:8080/case-notes
       - SERVICES_AP-OASYS-CONTEXT-API_BASE-URL=http://wiremock:8080
+      - SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL=http://wiremock:8080
       - SPRING_DATASOURCE_URL=jdbc:postgresql://database/approved_premises_localdev
       - SPRING_DATASOURCE_USERNAME=localdev
       - SPRING_DATASOURCE_PASSWORD=localdev_password

--- a/wiremock/mappings/ApDeliusContext_CheckManagingTeam.json
+++ b/wiremock/mappings/ApDeliusContext_CheckManagingTeam.json
@@ -1,0 +1,18 @@
+{
+  "id": "19ee3e44-c13e-4d65-91d0-cb7b78e7c913",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/teams/managingCase/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "teamCodes": [
+        "A00IAV"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
JimSnowLdap is a member of team `A00IAV` so the stub is configured to return that team as the managing team for all CRNs.  The URL for AP Delius Context API was also missing so that is now pointed at Wiremock.