### PR TITLE
Add a refresh flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /nomis-db
 /community-api-db
+/Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "yq"
+brew "tilt"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A suite of tools to help with development on the HMPPS Approved Premises project
 
 * Docker
 * [Tilt](https://tilt.dev/)
+* [YQ](https://mikefarah.gitbook.io/yq/)
 
 ## Getting started
 
@@ -89,3 +90,13 @@ ap-tools server stop
 ```
 
 This will stop all running `tilt` processes and tear down the entire stack.
+
+#### Refreshing containers
+
+Sometimes the stack will fail to come up cleanly, or you might want
+to get the latest version(s) of the containers. To do this, you
+can add a `--refresh` flag like so:
+
+```bash
+ap-tools server start --refresh
+```

--- a/bin/server
+++ b/bin/server
@@ -5,6 +5,7 @@ if ! [ "$(command -v tilt)" ];then
     exit
 fi
 
+"$(dirname "$0")/utils/install-dependencies.sh"
 "$(dirname "$0")/utils/launch-docker.sh"
 
 if [ -z "$1" ]; then

--- a/bin/start-server
+++ b/bin/start-server
@@ -19,6 +19,8 @@ do
         fi
         args="$args --local-api"
         ;;
+    --refresh)
+      "$(dirname "$0")/utils/refresh-containers.sh"
   esac
   shift
 done

--- a/bin/utils/install-dependencies.sh
+++ b/bin/utils/install-dependencies.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if command -v brew > /dev/null 2>&1
+then
+  echo "==> Installing dependencies..."
+  cd "$(dirname "$0")/../.." || exit
+  brew bundle
+fi

--- a/bin/utils/refresh-containers.sh
+++ b/bin/utils/refresh-containers.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo "==> Refreshing containers..."
+
+yq '.services[].image' "$(dirname "$0")/../../docker-compose.yml" | while read -r container; do docker pull "$container"; done
+
+rm -rf "$(dirname "$0")/community-api-db" && \
+rm -rf "$(dirname "$0")/nomis-db"


### PR DESCRIPTION
This will allow us to pull all the containers, delete the local databases, and start from scratch.

To make this a bit more robust, I’m using `yq` to fetch all the containers defined in the docker-compose file. With this in mind, I’ve added a Brewfile to automatically install the dependencies if the user has Homebrew installed.