### PR TITLE
Add localstack to the setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,5 +159,21 @@ services:
     ports:
       - "7341:8081"
 
+  localstack:
+    image: localstack/localstack:1.3.1
+    container_name: approved-premises-api-localstack
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+      - 8999:8080
+    environment:
+      - SERVICES=sns,sqs
+      - DEBUG=${DEBUG- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - DEFAULT_REGION=eu-west-2
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
 volumes:
   database-data-development:

--- a/tiltfile
+++ b/tiltfile
@@ -19,6 +19,7 @@ resources = [
     "prison-api",
     "redis",
     "hmpps-auth",
+    "localstack"
 ]
 
 if local_api:


### PR DESCRIPTION
The API now uses localstack to mock SQS in dev, so we need to add it to our containers or the API won't spin up