### PR TITLE
Point API at correct Localstack URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - SPRING_DATASOURCE_PASSWORD=localdev_password
       - SPRING_REDIS_HOST=redis
       - SPRING_REDIS_PORT=6379
+      - HMPPS_SQS_LOCALSTACKURL=http://approved-premises-api-localstack:4566
     ports:
       - 8080:8080
 


### PR DESCRIPTION
When the API is running in a container it needs to point Localstack traffic to the localstack container's host name instead of localhost