### PR TITLE
Upgrade to Redis 7.0.11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       - ./seed/prison-api:/seed
 
   redis:
-    image: "bitnami/redis:5.0"
+    image: "bitnami/redis:7.0.11"
     container_name: approved-premises-redis-dev
     environment:
       - ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
- Our environments are currently running version 4.x.x
- We've been asked to upgrade due to EOL
- I can't find out why we are using bitnami rather than the official redis image, to avoid potential problems with the upgrade I'm going to keep the surface area of problems smaller by staying with the same maintainer - one for later
- apparently redis supports backwards compatibility even between major changes[1] so we should be able to attempt the otherwise big jump in one go

[1] https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/redis/upgrade.html#upgrade-paths