### PR TITLE
Add JWKS URI to Prison API config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,7 @@ services:
       - SPRING_REPLICA_DATASOURCE_PASSWORD=password
       - LOGGING_LEVEL_UK_GOV_JUSTICE=debug
       - SPRING_FLYWAY_LOCATIONS=classpath:/db/migration/nomis/ddl,classpath:/db/migration/data,classpath:/db/migration/nomis/data,classpath:/db/migration/nomis/data-hsqldb,filesystem:/seed
+      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://hmpps-auth:8080/auth/.well-known/jwks.json
     volumes:
       - ./nomis-db:/nomis-db
       - ./seed/prison-api:/seed


### PR DESCRIPTION
Since https://github.com/ministryofjustice/prison-api/commit/cc4390bba61c7e823ba76fd837a9ffdd35487b8c the jwks is fetched from HMPPS Auth, rather than a local file. As we run HMPPS Auth on a different port, we need to set an environment var, so Prison API looks in the right place.