### PR TITLE
Fix path for deleting local dbs when passing '--refresh' option

### DIFF
--- a/bin/utils/refresh-containers.sh
+++ b/bin/utils/refresh-containers.sh
@@ -4,5 +4,6 @@ echo "==> Refreshing containers..."
 
 yq '.services[].image' "$(dirname "$0")/../../docker-compose.yml" | while read -r container; do docker pull "$container"; done
 
-rm -rf "$(dirname "$0")/community-api-db" && \
-rm -rf "$(dirname "$0")/nomis-db"
+rootpath="$(dirname "$0")/../../"
+rm -rf "$rootpath/community-api-db" && \
+rm -rf "$rootpath/nomis-db"


### PR DESCRIPTION
The Community API and Prisons dbs were not being deleted by the `--refresh` flag as the current directory was set to:

`bin/utils/` -- the location of the `refresh-containers.sh` script.

We now set a `rootpath` variable to take us up 2 levels so that the deletion works as expected.