### PR TITLE
Authenticate with NOMIS creds (as well as via Delius)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,19 @@ Server logs will then be avaiable in the browser at http://localhost:10350
 
 You will be able to log into the application at http://localhost:3000 with the following:
 
+##### Delius credentials
 - **Username:** `JIMSNOWLDAP`
 - **Password:** `secret`
+
+##### Nomis credentials
+Take your pick from the [users seeded in nomis-user-roles-api](https://github.com/ministryofjustice/nomis-user-roles-api/blob/main/src/main/resources/db/dev/V3_1__user_data.sql)
+
+e.g.
+
+- **Username:** `POM_USER`
+- **Password:** `password123456`
+
+##### CRNs
 
 There is also a usable CRN: `X320741`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,8 @@ services:
     healthcheck:
       test: ["CMD", "echo", "-n > '/dev/tcp/127.0.0.1/8080'"]
     environment:
-      - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_PROFILES_ACTIVE=dev,nomis,delius
+      - NOMIS_ENDPOINT_URL=http://nomis-user-roles-api:8080
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
       - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
       - DELIUS_ENABLED=true
@@ -144,6 +145,20 @@ services:
     volumes:
       - ./nomis-db:/nomis-db
       - ./seed/prison-api:/seed
+
+  nomis-user-roles-api:
+    image: quay.io/hmpps/nomis-user-roles-api:latest
+    container_name: nomis-user-roles-api
+    depends_on:
+      - hmpps-auth
+    ports:
+      - "8081:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=dev
+      - API_BASE_URL_OAUTH=http://hmpps-auth:8080/auth
 
   redis:
     image: "bitnami/redis:7.0.11"

--- a/tiltfile
+++ b/tiltfile
@@ -11,6 +11,7 @@ local_ui = cfg.get("local-ui", False)
 resources = [
     "api",
     "frontend",
+    "nomis-user-roles-api",
     "hmpps-auth",
     "community-api",
     "hmpps-assess-risks-and-needs",


### PR DESCRIPTION
CAS2 users are Prison Offender Managers (POMs) and so need
to authenticate with our service using their NOMIS credentials.

The [NOMIS User Roles API](https://github.com/ministryofjustice/nomis-user-roles-api)
project provides a mechanism to authenticate using a local
store of NOMIS users.

See https://github.com/ministryofjustice/nomis-user-roles-api/blob/main/src/main/resources/db/dev/V3_1__user_data.sql
for a list of available credentials.

We can now log in with either Delius creds (`JimSnowLdap`) or
NOMIS creds (e.g. `POM_USER`).