### PR TITLE
Add Wiremock integration for Adjudications API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - SERVICES_ASSESS-RISKS-AND-NEEDS-API_BASE-URL=http://hmpps-assess-risks-and-needs:8080
       - SERVICES_HMPPS-TIER_BASE-URL=http://wiremock:8080
       - SERVICES_PRISONS-API_BASE-URL=http://prison-api:8080
+      - SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL=http://wiremock:8080
       - SERVICES_CASE-NOTES_BASE-URL=http://wiremock:8080/case-notes
       - SERVICES_AP-OASYS-CONTEXT-API_BASE-URL=http://wiremock:8080
       - SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL=http://wiremock:8080

--- a/wiremock/mappings/AdjudicationsApi_GetAdjudicationsPage.json
+++ b/wiremock/mappings/AdjudicationsApi_GetAdjudicationsPage.json
@@ -1,0 +1,292 @@
+{
+  "id": "05c36ca3-f66c-4ffe-917e-65aff9567af2",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/adjudications/(.*)/adjudications*"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "results": {
+        "content": [
+          {
+            "adjudicationNumber": 1525965,
+            "reportTime": "2023-08-16T09:30:00",
+            "agencyIncidentId": 1503257,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "1525965/1",
+                "offenceCode": "51:16",
+                "offenceDescription": "Intentionally or recklessly sets fire to any part of a prison or any other property, whether or not his own",
+                "findingCode": "PROVED"
+              }
+            ]
+          },
+          {
+            "adjudicationNumber": 1525953,
+            "reportTime": "2023-08-15T13:41:00",
+            "agencyIncidentId": 1503253,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "1525953/1",
+                "offenceCode": "51:22",
+                "offenceDescription": "Disobeys any lawful order",
+                "findingCode": "PROVED"
+              }
+            ]
+          },
+          {
+            "adjudicationNumber": 1525940,
+            "reportTime": "2023-08-08T15:14:00",
+            "agencyIncidentId": 1503239,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "1525940/1",
+                "offenceCode": "55:1E",
+                "offenceDescription": "Commits any assault - all assault on other person"
+              }
+            ]
+          },
+          {
+            "adjudicationNumber": 1525931,
+            "reportTime": "2023-08-04T15:18:00",
+            "agencyIncidentId": 1503232,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "1525931/1",
+                "offenceCode": "51:25C",
+                "offenceDescription": "(a) Attempts to commit, (b) incites another inmate to commit, or (c) assists another inmate to commit or to attempt to commit, any of the foregoing offences - at incite or assist to set fire to prison or prop"
+              }
+            ]
+          },
+          {
+            "adjudicationNumber": 1525906,
+            "reportTime": "2023-08-01T13:56:17",
+            "agencyIncidentId": 1503196,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "1525906/1",
+                "offenceCode": "51:16",
+                "offenceDescription": "Intentionally or recklessly sets fire to any part of a prison or any other property, whether or not his own",
+                "findingCode": "PROVED"
+              }
+            ]
+          },
+          {
+            "adjudicationNumber": 2525906,
+            "reportTime": "2023-08-01T13:56:00",
+            "agencyIncidentId": 1503197,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "2525906/1",
+                "offenceCode": "51:16",
+                "offenceDescription": "Intentionally or recklessly sets fire to any part of a prison or any other property, whether or not his own"
+              }
+            ]
+          },
+          {
+            "adjudicationNumber": 1525901,
+            "reportTime": "2023-07-31T16:25:19",
+            "agencyIncidentId": 1503181,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "1525901/1",
+                "offenceCode": "51:23",
+                "offenceDescription": "Disobeys or fails to comply with any rule or regulation applying to him"
+              }
+            ]
+          },
+          {
+            "adjudicationNumber": 1525709,
+            "reportTime": "2023-06-02T11:25:31",
+            "agencyIncidentId": 1503053,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "1525709/1",
+                "offenceCode": "51:1F",
+                "offenceDescription": "Commits any assault - all assault on other person"
+              }
+            ]
+          },
+          {
+            "adjudicationNumber": 1525707,
+            "reportTime": "2023-06-02T10:30:14",
+            "agencyIncidentId": 1503051,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "1525707/1",
+                "offenceCode": "51:23",
+                "offenceDescription": "Disobeys or fails to comply with any rule or regulation applying to him"
+              }
+            ]
+          },
+          {
+            "adjudicationNumber": 1525705,
+            "reportTime": "2023-06-01T14:15:12",
+            "agencyIncidentId": 1503049,
+            "agencyId": "MDI",
+            "partySeq": 1,
+            "adjudicationCharges": [
+              {
+                "oicChargeId": "1525705/1",
+                "offenceCode": "51:16",
+                "offenceDescription": "Intentionally or recklessly sets fire to any part of a prison or any other property, whether or not his own",
+                "findingCode": "PROVED"
+              }
+            ]
+          }
+        ],
+        "pageable": {
+          "sort": {
+            "empty": true,
+            "unsorted": true,
+            "sorted": false
+          },
+          "offset": 0,
+          "pageNumber": 0,
+          "pageSize": 10,
+          "unpaged": false,
+          "paged": true
+        },
+        "totalPages": 3,
+        "totalElements": 29,
+        "last": false,
+        "size": 10,
+        "number": 0,
+        "sort": {
+          "empty": true,
+          "unsorted": true,
+          "sorted": false
+        },
+        "first": true,
+        "numberOfElements": 10,
+        "empty": false
+      },
+      "offences": [
+        {
+          "id": "194",
+          "code": "55:29C",
+          "description": "(a) Attempts to commit, (b) incites another inmate to commit, or (c) assists another inmate to commit or to attempt to commit, any of the foregoing offences - at incite or assist to set fire to prison or prop"
+        },
+        {
+          "id": "101",
+          "code": "51:25C",
+          "description": "(a) Attempts to commit, (b) incites another inmate to commit, or (c) assists another inmate to commit or to attempt to commit, any of the foregoing offences - at incite or assist to set fire to prison or prop"
+        },
+        {
+          "id": "109",
+          "code": "51:25K",
+          "description": "(a) Attempts to commit, (b) incites another inmate to commit, or (c) assists another inmate to commit or to attempt to commit, any of the foregoing offences - attempt,incite or assist detention of an inmate"
+        },
+        {
+          "id": "106",
+          "code": "51:25H",
+          "description": "(a) Attempts to commit, (b) incites another inmate to commit, or (c) assists another inmate to commit or to attempt to commit, any of the foregoing offences - attempt,incite or assist to deny access to officer"
+        },
+        {
+          "id": "121",
+          "code": "51:25W",
+          "description": "(a) Attempts to commit, (b) incites another inmate to commit, or (c) assists another inmate to commit or to attempt to commit, any of the foregoing offences - incite or assist the disobeying of an order"
+        },
+        {
+          "id": "171",
+          "code": "55:29AC",
+          "description": "(a) Attempts to commit, (b) incites another inmate to commit, or (c) assists another inmate to commit or to attempt to commit, any of the foregoing offences - incite the use of threats/abuse/insults"
+        },
+        {
+          "id": "92",
+          "code": "51:18A",
+          "description": "Absents himself from any place he is required to be or is present at any place where he is not authorised to be - absence without permission"
+        },
+        {
+          "id": "79",
+          "code": "51:1F",
+          "description": "Commits any assault - all assault on other person"
+        },
+        {
+          "id": "200",
+          "code": "55:1E",
+          "description": "Commits any assault - all assault on other person"
+        },
+        {
+          "id": "78",
+          "code": "51:1B",
+          "description": "Commits any assault - assault on inmate"
+        },
+        {
+          "id": "2",
+          "code": "51:1A",
+          "description": "Commits any racially aggravated assault"
+        },
+        {
+          "id": "84",
+          "code": "51:2C",
+          "description": "Detains any person against his will - detention against will of prison officer grade"
+        },
+        {
+          "id": "48",
+          "code": "51:22",
+          "description": "Disobeys any lawful order"
+        },
+        {
+          "id": "49",
+          "code": "51:23",
+          "description": "Disobeys or fails to comply with any rule or regulation applying to him"
+        },
+        {
+          "id": "17",
+          "code": "51:21",
+          "description": "Intentionally fails to work properly or, being required to work, refuses to do so"
+        },
+        {
+          "id": "13",
+          "code": "51:16",
+          "description": "Intentionally or recklessly sets fire to any part of a prison or any other property, whether or not his own"
+        },
+        {
+          "id": "18",
+          "code": "51:24",
+          "description": "Receives any controlled drug, or, without the consent of an officer, any other article, during the course of a visit (not being an interview such as is mentioned in rule 38)"
+        },
+        {
+          "id": "16",
+          "code": "51:20",
+          "description": "Uses threatening, abusive or insulting words or behaviour"
+        }
+      ],
+      "agencies": [
+        {
+          "agencyId": "MDI",
+          "description": "Moorland (HMP & YOI)",
+          "active": true
+        },
+        {
+          "agencyId": "WWI",
+          "description": "Wandsworth (HMP)",
+          "active": true
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This allows ap-tools to handle requests from the Approved Premises API to the Adjudications API, enabling the change in
https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/892/ to function within the ap-tools stack.