### PR TITLE
fix: use uppercase values for rosh risk ratings

### DIFF
--- a/wiremock/mappings/ApAndOasys_GetRoshRiskRatings.json
+++ b/wiremock/mappings/ApAndOasys_GetRoshRiskRatings.json
@@ -1,5 +1,5 @@
 {
-  "id": "3945dfc8-a31b-4877-9eeb-5ae391e8d6e1",
+  "id": "1112984a-9435-4a75-b0e1-30c6b4caf6d6",
   "request": {
     "method": "GET",
     "urlPathPattern": "/rosh/(.*)"
@@ -20,15 +20,15 @@
       "limitedAccessOffender": false,
       "lastUpdatedDate": "2022-11-29T10:37:22Z",
       "rosh": {
-        "riskChildrenCommunity": "Medium",
-        "riskPublicCommunity": "High",
-        "riskKnownAdultCommunity": "High",
-        "riskStaffCommunity": "Low",
-        "riskChildrenCustody": "Low",
-        "riskPublicCustody": "Low",
-        "riskKnownAdultCustody": "Low",
-        "riskStaffCustody": "Low",
-        "riskPrisonersCustody": "Low"
+        "riskChildrenCommunity": "MEDIUM",
+        "riskPublicCommunity": "HIGH",
+        "riskKnownAdultCommunity": "HIGH",
+        "riskStaffCommunity": "LOW",
+        "riskChildrenCustody": "LOW",
+        "riskPublicCustody": "LOW",
+        "riskKnownAdultCustody": "LOW",
+        "riskStaffCustody": "LOW",
+        "riskPrisonersCustody": "LOW"
       }
     }
   }


### PR DESCRIPTION
This mock was failing locally because we were using the text rather than
the value of the enum. The CAS API was not able to deserialise the
values and threw this error:

```
com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot
deserialize value of type
`uk.gov.justice.digital.hmpps.approvedpremisesapi.model.oasyscontext.RiskLevel`
from String "Medium": not one of the values accepted for
Enum class: [HIGH, VERY_HIGH, LOW, MEDIUM]
```

From looking at where it's returned by oasys integration API here:
https://github.com/ministryofjustice/hmpps-probation-integration-services/blob/b9f45438382167bb353e00790a5cc130938ab09f/projects/approved-premises-and-oasys/src/main/kotlin/uk/gov/justice/digital/hmpps/model/RoshDetails.kt#L64

There is a `fromString` method that converts the text value passed in
(e.g. "Very High") to the enum value (`VERY_HIGH`). So I am assuming
that we should be returning the enum value too, rather than changing our
API code.