### PR TITLE
Add new mocks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
       - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
       - DELIUS_ENABLED=true
-      - DELIUS_ENDPOINT_URL=http://community-api:8080
+      - DELIUS_ENDPOINT_URL=http://wiremock:8080
       - DELIUS_ENDPOINT_TIMEOUT=1s
       - DELIUS_CLIENT_CLIENT-ID=delius-auth-api-client
       - DELIUS_CLIENT_CLIENT-SECRET=delius-auth-api-client

--- a/wiremock/mappings/ApDeliusContext_GetCaseDetail.json
+++ b/wiremock/mappings/ApDeliusContext_GetCaseDetail.json
@@ -1,0 +1,61 @@
+{
+  "id": "331bc347-d9c7-42d9-9c47-217860c35749",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/probation-cases/(.*)/details"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "case": {
+        "crn": "X371199",
+        "nomsId": "A7779DY",
+        "name": {
+          "forename": "Ben",
+          "surname": "Davies",
+          "middleNames": []
+        },
+        "dateOfBirth": "1993-04-24",
+        "gender": "Male",
+        "profile": {
+          "ethnicity": "White: British/English/Welsh/Scottish/Northern Irish",
+          "genderIdentity": "Male",
+          "nationality": "British",
+          "religion": "Apostolic"
+        },
+        "manager": {
+          "team": {
+            "code": "N07UAT",
+            "name": "Unallocated Team(N07)",
+            "ldu": {
+              "code": "N07UAT",
+              "name": "Unallocated Level 3(N07)"
+            }
+          }
+        },
+        "currentExclusion": false,
+        "currentRestriction": false
+      },
+      "offences": [
+        {
+          "description": "Arson - 05600",
+          "date": "2021-01-06",
+          "main": true,
+          "eventNumber": "2"
+        }
+      ],
+      "registrations": [],
+      "mappaDetail": {
+        "level": 0,
+        "levelDescription": "string",
+        "category": 0,
+        "categoryDescription": "string",
+        "startDate": "2023-10-06",
+        "lastUpdated": "2023-10-06T13:11:16.559Z"
+      }
+    }
+  }
+}

--- a/wiremock/mappings/HmppsAuthAndDelius_Authenticate.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_Authenticate.json
@@ -1,0 +1,9 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/authenticate"
+  },
+  "response": {
+    "status": 200
+  }
+}

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPattern": "/user/.*"
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "jsonBody": {
+      "userId": 2500077027,
+      "username": "JIMSNOWLDAP",
+      "firstName": "Delius",
+      "surname": "Smith",
+      "email": "test@digital.justice.gov.uk",
+      "enabled": true,
+      "roles": ["ROLE_PROBATION"]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
This adds a new mock for a new Approved Premises and Delius endpoint, as well as fixes not being able to log in via HMPPS Auth, as the latest version of Auth now points to a custom integration, rather than Community API.