### PR TITLE
Add seeding for external CAS2_ASSESSOR_USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ e.g.
 - **Username:** `POM_USER`
 - **Password:** `password123456`
 
+##### External CAS2 Assessor
+CAS2 has a group of external users from the NACRO organisation who are granted the
+`CAS2_ASSESSOR` role and who have access to submitted CAS2 applications only.
+
+- **Username:** `CAS2_ASSESSOR_USER`
+- **Password:** `password123456`
+
 ##### CRNs
 
 There is also a usable CRN: `X320741`

--- a/bin/start-server
+++ b/bin/start-server
@@ -48,6 +48,8 @@ echo "Password: secret"
 echo ""
 echo "or Nomis user: POM_USER/password123456"
 echo ""
+echo "or external NACRO assessor: CAS2_ASSESSOR_USER/password123456"
+echo ""
 echo "There is also a usable CRN: X320741"
 
 exit 0

--- a/seed/hmpps-auth/V901_2__groups_roles.sql
+++ b/seed/hmpps-auth/V901_2__groups_roles.sql
@@ -1,0 +1,11 @@
+-- create CAS2 Assessors group
+INSERT INTO groups (group_id, group_code, group_name, create_datetime)
+VALUES ('a274e977-4ff8-43cf-9334-5b4703c1aff6', 'CAS2_ASSESSORS', 'CAS2 ASSESSORS', '2023-10-15 21:35:52.043333');
+
+-- create CAS2 Assessor role
+--   This will appear as the ROLE_CAS2_ASSESSOR authority in the JWT
+--   and can be referenced with either hasRole("CAS2_ASSESSOR") or
+--   hasAuthority("ROLE_CAS2_ASSESSOR") in Spring Security filters
+INSERT INTO roles (role_id, role_code, role_name, create_datetime, role_description, admin_type)
+VALUES ('f62b8a99-00c7-4250-8279-3eb80129eb19', 'CAS2_ASSESSOR', 'CAS2 Assessor', '2023-10-15 21:35:51.130000', null, 'EXT_ADM');
+

--- a/seed/hmpps-auth/V901_3__users.sql
+++ b/seed/hmpps-auth/V901_3__users.sql
@@ -1,0 +1,12 @@
+-- create CAS_2_ASSESSOR_USER
+ INSERT INTO users (user_id, username, password, email, first_name, last_name, verified, locked, enabled, master, create_datetime, password_expiry, last_logged_in, source, mfa_preference)
+ VALUES ('98cf4cf3-ec67-4ffe-a740-daee48676dc6', 'CAS2_ASSESSOR_USER', '{bcrypt}$2a$10$Fmcp2KUKRW53US3EJfsxkOh.ekZhqz5.Baheb9E98QLwEFLb9csxy', 'cas2.assessor@nacro.org.uk', 'CAS2', 'Assessor (NACRO)', true, false, true, false, '2023-10-15 11:48:34.2723638', '2040-04-26 16:17:28.4953990', '2040-03-05 11:48:34.2723638', 'auth', 'EMAIL');
+
+-- assign to Assessors group
+INSERT INTO user_group (group_id, user_id) SELECT group_id, user_id from groups, users where username = 'CAS2_ASSESSOR_USER' and group_code = 'CAS2_ASSESSORS';
+
+-- assign CAS2 Assessor role
+--   This will appear as the ROLE_CAS2_ASSESSOR authority in the JWT
+--   and can be referenced with either hasRole("CAS2_ASSESSOR") or
+--   hasAuthority("ROLE_CAS2_ASSESSOR") in Spring Security filters
+INSERT INTO user_role (role_id, user_id) SELECT role_id, user_id FROM roles, users WHERE username = 'CAS2_ASSESSOR_USER' AND role_code = 'CAS2_ASSESSOR';


### PR DESCRIPTION
We can now log in locally as an external NACRO user.

username: `CAS2_ASSESSOR_USER`
password: `password123456`

The important `claims` keys of the issued JWT will look like:

```json
{ "user_name": "CAS2_ASSESSOR_USER",
  "auth_source": "auth",
  "authorities": [
    "ROLE_CAS2_ASSESSOR"
  ],
}
```

This can be referenced with either `hasRole("CAS2_ASSESSOR")` or `hasAuthority("ROLE_CAS2_ASSESSOR")` in Spring Security filters