### PR TITLE
Add auto-update functionality to ap-tools command

### DIFF
--- a/bin/ap-tools
+++ b/bin/ap-tools
@@ -13,6 +13,7 @@ elif [ "$command" = "--help" ]; then
   echo "  --local-ui"
   echo "  --local-api"
   echo "  --refresh"
+  echo "  --no-update"
   
 else
   echo "Unknown command $1"

--- a/bin/start-server
+++ b/bin/start-server
@@ -2,6 +2,9 @@
 
 args=""
 
+do_update=1
+do_refresh=0
+
 while [ "$1" != "" ];
 do
    case $1 in
@@ -20,10 +23,24 @@ do
         args="$args --local-api"
         ;;
     --refresh)
-      "$(dirname "$0")/utils/refresh-containers.sh"
+        do_refresh=1
+        ;;
+    --no-update)
+        do_update=0
+        ;;
   esac
   shift
 done
+
+if [ $do_update -gt 0 ]; then
+  if "$(dirname "$0")/utils/check-for-update.sh"; then
+    do_refresh=1
+  fi
+fi
+
+if [ $do_refresh -gt 0 ]; then
+  "$(dirname "$0")/utils/refresh-containers.sh"
+fi
 
 echo "Starting the Approved Premises Stack. This might take a moment. Logs available at http://localhost:10350"
 

--- a/bin/utils/check-for-update.sh
+++ b/bin/utils/check-for-update.sh
@@ -1,0 +1,39 @@
+compare_revs() {
+  a="$(git rev-parse "$1")"
+  b="$(git rev-parse "$2")"
+  [ "$a" = "$b" ]
+}
+
+is_main() {
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  [ "$branch" = "main" ]
+}
+
+echo "==> Checking for updates..."
+
+current_dir="$(pwd)"
+cd "$(dirname "$0")" || exit 1
+
+if ! is_main; then
+  echo "Current branch is not 'main', skipping update checks."
+  cd "$current_dir" || exit 1
+  exit 1
+fi
+
+git fetch > /dev/null 2>&1
+
+if compare_revs "main" "origin/main"; then
+  echo "Current version of ap-tools is up-to-date."
+  cd "$current_dir" || exit 1
+  exit 1
+fi
+
+echo "New version of ap-tools found, updating."
+if git pull > /dev/null 2>&1; then
+  echo "Could not update ap-tools automatically. No changes have been made."
+  cd "$current_dir" || exit 1
+  exit 1
+fi
+
+echo "Updated to latest version of ap-tools."
+cd "$current_dir" || exit


### PR DESCRIPTION
This provides a convenience functionality to ap-tools so that upstream changes are propagated to users without manual intervention, minimising errors due to outdated integrations.

Updates will occur when:
1. The current ap-tools branch is `main` (to avoid trampling over any potential changes in-flight)
2. The upstream version of `main` is different to the local version
3. The upstream version can be successfully `git pull`ed

If an update occurs, this will also automatically trigger a container refresh (as if the `--refresh` flag had been specified).

Automatic updates can be prevented by using the `--no-update` flag.