### PR TITLE
Mock response from `probation-offender-search`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - SERVICES_HMPPS-TIER_BASE-URL=http://wiremock:8080
       - SERVICES_PRISONS-API_BASE-URL=http://prison-api:8080
       - SERVICES_MANAGE-ADJUDICATIONS-API_BASE-URL=http://wiremock:8080
+      - SERVICES_PROBATION-OFFENDER-SEARCH-API_BASE-URL=http://wiremock:8080
       - SERVICES_CASE-NOTES_BASE-URL=http://wiremock:8080/case-notes
       - SERVICES_AP-OASYS-CONTEXT-API_BASE-URL=http://wiremock:8080
       - SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL=http://wiremock:8080

--- a/wiremock/mappings/ProbationOffenderSearchApi_SearchByNomsNumber.json
+++ b/wiremock/mappings/ProbationOffenderSearchApi_SearchByNomsNumber.json
@@ -1,0 +1,164 @@
+{
+  "id": "05c36ca3-f66c-4ffe-917e-65aff9567af2",
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/search.*",
+    "bodyPatterns": [
+      {
+          "equalToJson": { "nomsNumber": "A1234AI" }
+      }
+  ]
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": [
+      {
+        "offenderId": 1,
+        "softDeleted": false,
+        "otherIds": {
+          "crn": "X320741",
+          "pncNumber": "2018/0123456X",
+          "croNumber": "SF80/655108T",
+          "nomsNumber": "A1234AI",
+          "previousCrn": "X10001",
+          "mostRecentPrisonerNumber": "38510A"
+        },
+        "title": "Mr",
+        "firstName": "Aadland",
+        "middleNames": [],
+        "surname": "Bertrand",
+        "previousSurnames": [],
+        "dateOfBirth": "1978-01-06",
+        "age": "45",
+        "gender": "Male",
+        "currentDisposal": "1",
+        "currentExclusion": false,
+        "currentRestriction": false,
+        "partitionArea": "some name",
+        "currentTier": "UD2",
+        "offenderAliases": [
+        ],
+        "contactDetails": {
+          "addresses": [
+            {
+              "id": "1200034567",
+              "from": "2018-01-16",
+              "addressNumber": "12",
+              "buildingName": "string",
+              "county": "string",
+              "district": "string",
+              "noFixedAbode": true,
+              "notes": "string",
+              "postcode": "NE2 2SW",
+              "streetName": "Church Street Lane",
+              "telephoneNumber": "string",
+              "town": "Newcastle under Lyme",
+              "status": {
+                "code":"m",
+                "description": "main"
+              },
+              "type": {
+                "code": "A07B",
+                "description": "Friends/Family (settled)"
+              },
+              "createdDateTime": "2022-08-12T10:30:27",
+              "lastUpdatedDateTime": "2022-08-12T10:30:27"
+            }
+          ],
+          "emailAddresses": [],
+          "phoneNumbers": [],
+          "allowSMS": true
+        },
+        "offenderProfile": {
+          "riskColour": "red",
+          "ethnicity": "White British",
+          "immigrationStatus": null,
+          "nationality": "British",
+          "notes": "string",
+          "offenderDetails": "Induction pack completed on IA on 12/07/2022. SD Updated phone number 07000 000 000",
+          "offenderLanguages": {
+            "languageConcerns": "string",
+            "otherLanguages": [
+              "string"
+            ],
+            "primaryLanguage": "string",
+            "requiresInterpreter": true
+          },
+          "previousConviction": {
+            "detail": {}
+          },
+          "religion": "Apostolic",
+          "remandStatus": "Bail - Conditional",
+          "secondaryNationality": "string",
+          "sexualOrientation": "string"
+        },
+        "mappa": {
+          "level": 1,
+          "levelDescription": "MAPPA Level 1",
+          "category": 2,
+          "categoryDescription": "MAPPA Category 2",
+          "startDate": "2021-02-08",
+          "reviewDate": "2021-05-08",
+          "team": {
+            "code": "NO2AAM",
+            "description": "OMIC OMU A"
+          },
+          "officer": {
+            "code": "NO2AAMU",
+            "forenames": "Unallocated",
+            "surname": "Staff"
+          },
+          "probationArea": {
+            "code": "NO2",
+            "description": "NPS London"
+          },
+          "notes": "Level 1 Cat 2 notes"
+        },
+        "probationStatus": {
+          "status": "CURRENT",
+          "previouslyKnownTerminationDate": "2021-02-08",
+          "preSentenceActivity": false,
+          "awaitingPsr": true,
+          "inBreach": true
+        },
+        "offenderManagers": [
+          {
+            "fromDate": "2022-10-17",
+            "allocationReason": {
+              "code": "CAI",
+              "description": "Caseload Allocation"
+            },
+            "partitionArea": "National Data",
+            "active": true,
+            "staff": {
+              "code": "N02UATU",
+              "surname": "Staff",
+              "forenames": "Unallocated Staff(N02)",
+              "unallocated": true
+            },
+            "team": {
+              "code": "N02UAT",
+              "description": "Unallocated Team (N02)",
+              "district": {
+                "code": "N02DT1",
+                "description": "District One (N02)"
+              },
+              "borough": {
+                "code": "N02BR1",
+                "description": "Borough One(N02)"
+              }
+            },
+            "softDeleted": false,
+            "probationArea": {
+              "code": "N02",
+              "description": "NPS North East"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
We need to allow a CAS2 user to search for an offender by prison nubmber (`nomsNumber`). This adds a mocked response from the `probation-offender-search` API for searches using Aadland Bertland's `nomsNumber`. I think the shape of the data returned should match a prisoner detail from the probation API, which is a list of `OffenderDetails`.

See their controller tests:

https://github.com/ministryofjustice/probation-offender-search/blob/7093fdf716f969de3b80827675f8389cef01f95c/src/test/kotlin/uk/gov/justice/hmpps/probationsearch/controllers/OffenderSearchControllerTest.kt

And test fixtures:

https://github.com/ministryofjustice/probation-offender-search/blob/a6add4b33fd2aca9928da2cdd4bd276a101dd8b3/src/test/resources/searchdata/james-brown.json

But I haven't been able to see a 'real' response from the probation API yet, as I've been working from an office without my MoJ laptop which is needed to generate oAuth token and make a curl request:

```
curl -s --location \
         --request POST "https://sign-in-dev.hmpps.service.justice.gov.uk/auth/oauth/token?grant_type=client_credentials" \
         --header "Authorization: Basic $(echo -n $CLIENT_ID:$CLIENT_SECRET | base64)" -o token.txt
```

I did try to create a docker container for the service, but was unable to get it to connect to an opensearch node, and [was advised by Matt Ryall that it would be better to mock](https://mojdt.slack.com/archives/CR5ESQ8T1/p1700156787820239?thread_ts=1700140830.790789&cid=CR5ESQ8T1) (it's also [what make recall are doing](https://github.com/ministryofjustice/make-recall-decision-api/blob/fc00f6a03ca9f7826c45562cad365f1f913f0f10/docker-compose.yml#L58C2-L58C28)

The corresponding API PR is here  https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1152 