### PR TITLE
add Licence Case Admin user for CAS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ CAS2 has a group of NOMIS/DPS users who can view all submitted applications.
 - **Username:** `CAS2_ADMIN_USER`
 - **Password:** `password123456`
 
+###### CAS2 Licence Case Admin
+
+CAS2 allows Nomis users with the Licence Case Admin role to view applications for their prison.
+
+- **Username:** `CAS2_LICENCE_USER`
+- **Password:** `password123456`
+
 ##### CRNs
 
 There is also a usable CRN: `X320741`

--- a/bin/start-server
+++ b/bin/start-server
@@ -70,6 +70,7 @@ echo ""
 echo "  also: - external CAS2_ASSESSOR_USER/password123456 (ROLE_CAS2_ASSESSOR)"
 echo "        - Nomis user CAS2_MI_USER/password123456 (ROLE_CAS2_MI)"
 echo "        - Nomis user CAS2_ADMIN_USER/password123456 (ROLE_CAS2_ADMIN)"
+echo "        - Nomis user CAS2_LICENCE_USER/password123456 (ROLE_LICENCE_CA)"
 echo ""
 echo "There is also a usable CRN: X320741"
 

--- a/seed/nomis-user-roles/V3_2__user_data.sql
+++ b/seed/nomis-user-roles/V3_2__user_data.sql
@@ -53,3 +53,27 @@ insert into OMS_ROLES (ROLE_ID, ROLE_CODE, ROLE_NAME, ROLE_TYPE, ROLE_FUNCTION, 
 --   and can be referenced with either hasRole("CAS2_ADMIN") or
 --   hasAuthority("ROLE_CAS2_ADMIN") in Spring Security filters
 INSERT INTO USER_CASELOAD_ROLES (ROLE_ID, CASELOAD_ID, USERNAME) VALUES ((SELECT ROLE_ID FROM OMS_ROLES WHERE ROLE_CODE = 'CAS2_ADMIN'), 'NWEB', 'CAS2_ADMIN_USER');
+
+-- SET UP CAS2_LICENCE_USER
+--  this is all copied from HMPPS-Auth, see:
+--  https://github.com/ministryofjustice/hmpps-auth/blob/main/src/main/resources/db/dev/data/auth/V900_3__users.sql
+CREATE USER IF NOT EXISTS CAS2_LICENCE_USER password 'password123456';
+
+INSERT INTO STAFF_MEMBERS (STAFF_ID, FIRST_NAME, LAST_NAME, STATUS) VALUES (3030, 'CAS2', 'Licence Case Admin', 'ACTIVE');
+
+INSERT INTO STAFF_USER_ACCOUNTS (username, staff_user_type, staff_id, working_caseload_id, id_source)
+VALUES ('CAS2_LICENCE_USER', 'GENERAL', 3030, 'BAI', 'USER');
+
+INSERT INTO DBA_USERS (username, account_status, profile)
+VALUES ('CAS2_LICENCE_USER', 'OPEN', 'TAG_GENERAL');
+
+INSERT INTO SYS.USER$ (name, spare4)
+VALUES ('CAS2_LICENCE_USER', 'S:C59371608F601E454682E0B5293F2752A1DC31C4BDEF9D50802212AD981E');
+
+INSERT INTO USER_ACCESSIBLE_CASELOADS (CASELOAD_ID, USERNAME, START_DATE) VALUES ('NWEB', 'CAS2_LICENCE_USER', now());
+
+-- assign ROLE_LICENCE_CA role to CAS2_LICENCE_USER
+-- This will appear as the ROLE_LICENCE_CA authority in the JWT
+--   and can be referenced with either hasRole("LICENCE_CA") or
+--   hasAuthority("ROLE_LICENCE_CA") in Spring Security filters
+INSERT INTO USER_CASELOAD_ROLES (ROLE_ID, CASELOAD_ID, USERNAME) VALUES ((SELECT ROLE_ID FROM OMS_ROLES WHERE ROLE_CODE = 'LICENCE_CA'), 'NWEB', 'CAS2_LICENCE_USER');


### PR DESCRIPTION
we would like Nomis users with the LICENCE_CA role to have read access to applications for their prison. This seeds the user for the nomis_user_roles API,
and adds documentation.