### PR TITLE
Start mocking requests for NOMS number A5671YZ

### DIFF
--- a/bin/start-server
+++ b/bin/start-server
@@ -72,6 +72,7 @@ echo "        - Nomis user CAS2_MI_USER/password123456 (ROLE_CAS2_MI)"
 echo "        - Nomis user CAS2_ADMIN_USER/password123456 (ROLE_CAS2_ADMIN)"
 echo "        - Nomis user CAS2_LICENCE_USER/password123456 (ROLE_LICENCE_CA)"
 echo ""
-echo "There is also a usable CRN: X320741"
+echo "There is a usable CRN: X320741 (NOMS_NUMBER: A1234AI)"
+echo "There is partial support for a second CRN: C246139 (NOMS_NUMBER: A5671YZ)"
 
 exit 0

--- a/wiremock/mappings/ApAndOasys_GetOffenceAnalysis.json
+++ b/wiremock/mappings/ApAndOasys_GetOffenceAnalysis.json
@@ -1,5 +1,6 @@
 {
   "id": "f5f0e36b-84a5-4169-92f3-3719cec200f4",
+  "priority": 2,
   "request": {
     "method": "GET",
     "urlPathPattern": "/offence-details/(.*)"

--- a/wiremock/mappings/ApAndOasys_GetRisksToTheIndividual.json
+++ b/wiremock/mappings/ApAndOasys_GetRisksToTheIndividual.json
@@ -1,5 +1,6 @@
 {
   "id": "5bea7fae-090b-4010-b0bc-bf4d9068b2bd",
+  "priority": 2,
   "request": {
     "method": "GET",
     "urlPathPattern": "/risk-to-the-individual/(.*)"
@@ -32,4 +33,3 @@
     }
   }
 }
-

--- a/wiremock/mappings/noms_number_A5671YZ/ApAndOasys_GetOffenceAnalysis.json
+++ b/wiremock/mappings/noms_number_A5671YZ/ApAndOasys_GetOffenceAnalysis.json
@@ -1,0 +1,15 @@
+{
+  "id": "f5f0e36b-84a5-4169-92f3-3719cec200f4",
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offence-details/C246139"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 404,
+    "body": "{\"message\":\"Resource not found\"}"
+  }
+}

--- a/wiremock/mappings/noms_number_A5671YZ/ApAndOasys_GetRisksToTheIndividual.json
+++ b/wiremock/mappings/noms_number_A5671YZ/ApAndOasys_GetRisksToTheIndividual.json
@@ -1,0 +1,15 @@
+{
+  "id": "5bea7fae-090b-4010-b0bc-bf4d9068b2bd",
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/risk-to-the-individual/C246139"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 404,
+    "body": "{\"message\":\"Resource not found\"}"
+  }
+}

--- a/wiremock/mappings/noms_number_A5671YZ/ProbationOffenderSearchApi_SearchByNomsNumber.json
+++ b/wiremock/mappings/noms_number_A5671YZ/ProbationOffenderSearchApi_SearchByNomsNumber.json
@@ -1,0 +1,164 @@
+{
+  "id": "05c36ca3-f66c-4ffe-917e-65aff9567af2",
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/search.*",
+    "bodyPatterns": [
+      {
+          "equalToJson": { "nomsNumber": "A5671YZ" }
+      }
+  ]
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": [
+      {
+        "offenderId": 1,
+        "softDeleted": false,
+        "otherIds": {
+          "crn": "C246139",
+          "pncNumber": "2018/0123456Y",
+          "croNumber": "SF80/655108S",
+          "nomsNumber": "A5671YZ",
+          "previousCrn": "X10001",
+          "mostRecentPrisonerNumber": "38510B"
+        },
+        "title": "Mr",
+        "firstName": "James",
+        "middleNames": [],
+        "surname": "Brown",
+        "previousSurnames": [],
+        "dateOfBirth": "1979-03-12",
+        "age": "45",
+        "gender": "Male",
+        "currentDisposal": "1",
+        "currentExclusion": false,
+        "currentRestriction": false,
+        "partitionArea": "some name",
+        "currentTier": "UD2",
+        "offenderAliases": [
+        ],
+        "contactDetails": {
+          "addresses": [
+            {
+              "id": "1200034567",
+              "from": "2018-01-16",
+              "addressNumber": "12",
+              "buildingName": "string",
+              "county": "string",
+              "district": "string",
+              "noFixedAbode": true,
+              "notes": "string",
+              "postcode": "NE2 2SW",
+              "streetName": "Church Street Lane",
+              "telephoneNumber": "string",
+              "town": "Newcastle under Lyme",
+              "status": {
+                "code":"m",
+                "description": "main"
+              },
+              "type": {
+                "code": "A07B",
+                "description": "Friends/Family (settled)"
+              },
+              "createdDateTime": "2022-08-12T10:30:27",
+              "lastUpdatedDateTime": "2022-08-12T10:30:27"
+            }
+          ],
+          "emailAddresses": [],
+          "phoneNumbers": [],
+          "allowSMS": true
+        },
+        "offenderProfile": {
+          "riskColour": "red",
+          "ethnicity": "White British",
+          "immigrationStatus": null,
+          "nationality": "British",
+          "notes": "string",
+          "offenderDetails": "Induction pack completed on IA on 12/07/2022. SD Updated phone number 07000 000 000",
+          "offenderLanguages": {
+            "languageConcerns": "string",
+            "otherLanguages": [
+              "string"
+            ],
+            "primaryLanguage": "string",
+            "requiresInterpreter": true
+          },
+          "previousConviction": {
+            "detail": {}
+          },
+          "religion": "Apostolic",
+          "remandStatus": "Bail - Conditional",
+          "secondaryNationality": "string",
+          "sexualOrientation": "string"
+        },
+        "mappa": {
+          "level": 1,
+          "levelDescription": "MAPPA Level 1",
+          "category": 2,
+          "categoryDescription": "MAPPA Category 2",
+          "startDate": "2021-02-08",
+          "reviewDate": "2021-05-08",
+          "team": {
+            "code": "NO2AAM",
+            "description": "OMIC OMU A"
+          },
+          "officer": {
+            "code": "NO2AAMU",
+            "forenames": "Unallocated",
+            "surname": "Staff"
+          },
+          "probationArea": {
+            "code": "NO2",
+            "description": "NPS London"
+          },
+          "notes": "Level 1 Cat 2 notes"
+        },
+        "probationStatus": {
+          "status": "CURRENT",
+          "previouslyKnownTerminationDate": "2021-02-08",
+          "preSentenceActivity": false,
+          "awaitingPsr": true,
+          "inBreach": true
+        },
+        "offenderManagers": [
+          {
+            "fromDate": "2022-10-17",
+            "allocationReason": {
+              "code": "CAI",
+              "description": "Caseload Allocation"
+            },
+            "partitionArea": "National Data",
+            "active": true,
+            "staff": {
+              "code": "N02UATU",
+              "surname": "Staff",
+              "forenames": "Unallocated Staff(N02)",
+              "unallocated": true
+            },
+            "team": {
+              "code": "N02UAT",
+              "description": "Unallocated Team (N02)",
+              "district": {
+                "code": "N02DT1",
+                "description": "District One (N02)"
+              },
+              "borough": {
+                "code": "N02BR1",
+                "description": "Borough One(N02)"
+              }
+            },
+            "softDeleted": false,
+            "probationArea": {
+              "code": "N02",
+              "description": "NPS North East"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Problem

CAS2 want to write a new E2E test to cover the case where an OASYS record exists but is older than 6 months, in which case the stack returns a 404 instead. We know this happens often enough and so we believe it warrants test coverage.

![Screenshot 2024-05-01 at 17-18-15 Import the person's risk to self data from OASys - Short-Term Accommodation (CAS-2)](https://github.com/ministryofjustice/hmpps-approved-premises-tools/assets/912473/1e1abe4f-ed98-43d3-92b7-0c0d2e082403)

## Notes

- The CAS2 FE asks the API for an oasys record via `/cas2/people/X320741/oasys/risk-to-self`. [This people controller will then make two requests for oasys data](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/7128dba72aeb13c6f72a1f7a678671d869f12350/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/PeopleController.kt#L51) and those requests will we now stub out with 404s with our new mocks. There are lots of other mocks we _could_ write, visible by other mapping files, but we with this we are able to start an application and jump to the risk section and see the above 404, which may be enough for the e2e test
- The [API](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/7128dba72aeb13c6f72a1f7a678671d869f12350/docker-compose.yml#L55) and [AP Tools](https://github.com/ministryofjustice/hmpps-approved-premises-tools/blob/64fec09836b62c94b9bc4d443f5c826c3acffaf2/docker-compose.yml#L122) **both** have Wiremock configuration. I use [Tilt/Ap tools with `--local-api`](https://github.com/ministryofjustice/hmpps-approved-premises-tools/tree/main?tab=readme-ov-file#running-local-instances-of-the-ui-or-api) so believed I'd be using the former. It turns out that that Wiremock instance is not used and in all cases the Tools Wiremock instance and mapping configuration is used. We probably don't want to remove it because we should be able to run the API without Tools so I'll at least signal with a comment over on that repo
- I did try another NOMS/CRN combo (NOMS_NUMBER = 'A9876RS' WHERE CRN = 'X320811') that we found in x. This fell over when mocking things on the request to `/probation-cases/summaries` which [we mock](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/7128dba72aeb13c6f72a1f7a678671d869f12350/wiremock/mappings/ApDeliusContext_GetCaseSummaries.json). This request is a GET request but expects a _body_ of CRNs which is not following the standard http - why is this not a query param?. This I discovered is not something Wiremock will map to, so I couldn't write a mock to intercept the request and so constantly got a 404. Instead we have to ensure this request passes through Wiremock and hits the local container of the real [probation-integration-service](https://github.com/ministryofjustice/hmpps-probation-integration-services/blob/main/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt#L14)