### PR TITLE
APS-768 Fail server start if errors occur

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 if ! [ "$(command -v tilt)" ];then
     echo "Tilt could not be found. Install with ``brew install tilt`` and try again"
     exit

--- a/bin/start-server
+++ b/bin/start-server
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 args=""
 
 do_update=1

--- a/bin/utils/install-or-update-intergration-services.sh
+++ b/bin/utils/install-or-update-intergration-services.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 integration_services_dir="hmpps-probation-integration-services"
 
 cd "$(dirname "$0")/../.." || exit
@@ -9,5 +11,5 @@ if [ -d $integration_services_dir ]; then
   cd $integration_services_dir && git pull > /dev/null 2>&1
 else
   echo "==> Cloning hmpps-probation-integration-services..."
-  git clone git@github.com:ministryofjustice/hmpps-probation-integration-services.git
+  git clone https://github.com/ministryofjustice/hmpps-probation-integration-services.git
 fi


### PR DESCRIPTION
This commit also changes the probation-integration clone to use https instead of ssh as this is more widely supported