### PR TITLE
CAS2-465: update local prison data

### DIFF
--- a/bin/start-server
+++ b/bin/start-server
@@ -75,6 +75,6 @@ echo "        - Nomis user CAS2_ADMIN_USER/password123456 (ROLE_CAS2_ADMIN)"
 echo "        - Nomis user CAS2_LICENCE_USER/password123456 (ROLE_LICENCE_CA)"
 echo ""
 echo "There is a usable CRN: X320741 (NOMS_NUMBER: A1234AI)"
-echo "There is partial support for a second CRN: C246139 (NOMS_NUMBER: A5671YZ)"
+echo "There is partial support for a second CRN: C246139 (NOMS_NUMBER: A1234AJ)"
 
 exit 0

--- a/seed/nomis-user-roles/V3_2__user_data.sql
+++ b/seed/nomis-user-roles/V3_2__user_data.sql
@@ -1,3 +1,8 @@
+-- ASSING PRISON CODE TO POM_USER
+-- this user is already seeded, but we want the prison code to match our example noms numbers
+UPDATE STAFF_USER_ACCOUNTS 
+SET working_caseload_id = 'LEI'
+WHERE username = 'POM_USER';
 
 -- SET UP CAS2_MI_USER
 --  this is all copied from HMPPS-Auth, see:
@@ -8,7 +13,7 @@ CREATE USER IF NOT EXISTS CAS2_MI_USER password 'password123456';
 INSERT INTO STAFF_MEMBERS (STAFF_ID, FIRST_NAME, LAST_NAME, STATUS) VALUES (2929, 'CAS2', 'MI User', 'ACTIVE');
 
 INSERT INTO STAFF_USER_ACCOUNTS (username, staff_user_type, staff_id, working_caseload_id, id_source)
-VALUES ('CAS2_MI_USER', 'GENERAL', 2929, 'BAI', 'USER');
+VALUES ('CAS2_MI_USER', 'GENERAL', 2929, 'LEI', 'USER');
 
 INSERT INTO DBA_USERS (username, account_status, profile)
 VALUES ('CAS2_MI_USER', 'OPEN', 'TAG_GENERAL');
@@ -36,7 +41,7 @@ CREATE USER IF NOT EXISTS CAS2_ADMIN_USER password 'password123456';
 INSERT INTO STAFF_MEMBERS (STAFF_ID, FIRST_NAME, LAST_NAME, STATUS) VALUES (2930, 'CAS2', 'Admin User', 'ACTIVE');
 
 INSERT INTO STAFF_USER_ACCOUNTS (username, staff_user_type, staff_id, working_caseload_id, id_source)
-VALUES ('CAS2_ADMIN_USER', 'GENERAL', 2930, 'BAI', 'USER');
+VALUES ('CAS2_ADMIN_USER', 'GENERAL', 2930, 'LEI', 'USER');
 
 INSERT INTO DBA_USERS (username, account_status, profile)
 VALUES ('CAS2_ADMIN_USER', 'OPEN', 'TAG_GENERAL');
@@ -62,7 +67,7 @@ CREATE USER IF NOT EXISTS CAS2_LICENCE_USER password 'password123456';
 INSERT INTO STAFF_MEMBERS (STAFF_ID, FIRST_NAME, LAST_NAME, STATUS) VALUES (3030, 'CAS2', 'Licence Case Admin', 'ACTIVE');
 
 INSERT INTO STAFF_USER_ACCOUNTS (username, staff_user_type, staff_id, working_caseload_id, id_source)
-VALUES ('CAS2_LICENCE_USER', 'GENERAL', 3030, 'BAI', 'USER');
+VALUES ('CAS2_LICENCE_USER', 'GENERAL', 3030, 'LEI', 'USER');
 
 INSERT INTO DBA_USERS (username, account_status, profile)
 VALUES ('CAS2_LICENCE_USER', 'OPEN', 'TAG_GENERAL');

--- a/wiremock/mappings/noms_number_A1234AJ/ApAndOasys_GetOffenceAnalysis.json
+++ b/wiremock/mappings/noms_number_A1234AJ/ApAndOasys_GetOffenceAnalysis.json
@@ -1,0 +1,15 @@
+{
+  "id": "f5f0e36b-84a5-4169-92f3-3719cec200f4",
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offence-details/C246139"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 404,
+    "body": "{\"message\":\"Resource not found\"}"
+  }
+}

--- a/wiremock/mappings/noms_number_A1234AJ/ApAndOasys_GetRisksToTheIndividual.json
+++ b/wiremock/mappings/noms_number_A1234AJ/ApAndOasys_GetRisksToTheIndividual.json
@@ -1,0 +1,15 @@
+{
+  "id": "5bea7fae-090b-4010-b0bc-bf4d9068b2bd",
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/risk-to-the-individual/C246139"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 404,
+    "body": "{\"message\":\"Resource not found\"}"
+  }
+}

--- a/wiremock/mappings/noms_number_A1234AJ/ProbationOffenderSearchApi_SearchByNomsNumber.json
+++ b/wiremock/mappings/noms_number_A1234AJ/ProbationOffenderSearchApi_SearchByNomsNumber.json
@@ -1,0 +1,164 @@
+{
+  "id": "05c36ca3-f66c-4ffe-917e-65aff9567af2",
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/search.*",
+    "bodyPatterns": [
+      {
+          "equalToJson": { "nomsNumber": "A1234AJ" }
+      }
+  ]
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": [
+      {
+        "offenderId": 1,
+        "softDeleted": false,
+        "otherIds": {
+          "crn": "C246139",
+          "pncNumber": "2018/0123456Y",
+          "croNumber": "SF80/655108S",
+          "nomsNumber": "A1234AJ",
+          "previousCrn": "X10001",
+          "mostRecentPrisonerNumber": "38510B"
+        },
+        "title": "Mr",
+        "firstName": "James",
+        "middleNames": [],
+        "surname": "Brown",
+        "previousSurnames": [],
+        "dateOfBirth": "1979-03-12",
+        "age": "45",
+        "gender": "Male",
+        "currentDisposal": "1",
+        "currentExclusion": false,
+        "currentRestriction": false,
+        "partitionArea": "some name",
+        "currentTier": "UD2",
+        "offenderAliases": [
+        ],
+        "contactDetails": {
+          "addresses": [
+            {
+              "id": "1200034567",
+              "from": "2018-01-16",
+              "addressNumber": "12",
+              "buildingName": "string",
+              "county": "string",
+              "district": "string",
+              "noFixedAbode": true,
+              "notes": "string",
+              "postcode": "NE2 2SW",
+              "streetName": "Church Street Lane",
+              "telephoneNumber": "string",
+              "town": "Newcastle under Lyme",
+              "status": {
+                "code":"m",
+                "description": "main"
+              },
+              "type": {
+                "code": "A07B",
+                "description": "Friends/Family (settled)"
+              },
+              "createdDateTime": "2022-08-12T10:30:27",
+              "lastUpdatedDateTime": "2022-08-12T10:30:27"
+            }
+          ],
+          "emailAddresses": [],
+          "phoneNumbers": [],
+          "allowSMS": true
+        },
+        "offenderProfile": {
+          "riskColour": "red",
+          "ethnicity": "White British",
+          "immigrationStatus": null,
+          "nationality": "British",
+          "notes": "string",
+          "offenderDetails": "Induction pack completed on IA on 12/07/2022. SD Updated phone number 07000 000 000",
+          "offenderLanguages": {
+            "languageConcerns": "string",
+            "otherLanguages": [
+              "string"
+            ],
+            "primaryLanguage": "string",
+            "requiresInterpreter": true
+          },
+          "previousConviction": {
+            "detail": {}
+          },
+          "religion": "Apostolic",
+          "remandStatus": "Bail - Conditional",
+          "secondaryNationality": "string",
+          "sexualOrientation": "string"
+        },
+        "mappa": {
+          "level": 1,
+          "levelDescription": "MAPPA Level 1",
+          "category": 2,
+          "categoryDescription": "MAPPA Category 2",
+          "startDate": "2021-02-08",
+          "reviewDate": "2021-05-08",
+          "team": {
+            "code": "NO2AAM",
+            "description": "OMIC OMU A"
+          },
+          "officer": {
+            "code": "NO2AAMU",
+            "forenames": "Unallocated",
+            "surname": "Staff"
+          },
+          "probationArea": {
+            "code": "NO2",
+            "description": "NPS London"
+          },
+          "notes": "Level 1 Cat 2 notes"
+        },
+        "probationStatus": {
+          "status": "CURRENT",
+          "previouslyKnownTerminationDate": "2021-02-08",
+          "preSentenceActivity": false,
+          "awaitingPsr": true,
+          "inBreach": true
+        },
+        "offenderManagers": [
+          {
+            "fromDate": "2022-10-17",
+            "allocationReason": {
+              "code": "CAI",
+              "description": "Caseload Allocation"
+            },
+            "partitionArea": "National Data",
+            "active": true,
+            "staff": {
+              "code": "N02UATU",
+              "surname": "Staff",
+              "forenames": "Unallocated Staff(N02)",
+              "unallocated": true
+            },
+            "team": {
+              "code": "N02UAT",
+              "description": "Unallocated Team (N02)",
+              "district": {
+                "code": "N02DT1",
+                "description": "District One (N02)"
+              },
+              "borough": {
+                "code": "N02BR1",
+                "description": "Borough One(N02)"
+              }
+            },
+            "softDeleted": false,
+            "probationArea": {
+              "code": "N02",
+              "description": "NPS North East"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR makes two changes to ensure our users will be able to make applications for offenders in their prison.

1. changes the secondary offender's nomsNumber - from [Prison API seeded data here,](https://github.com/ministryofjustice/prison-api/blob/37b7392bc69960f159de27e72aee19a9ae7e6ad5/src/main/resources/db/migration/data/R__1_15__OFFENDERS.sql#L26) retaining the old path temporarily until we have updated the UI e2e tests.
2. changes the active agency ID of our local users to match our local offenders

## Context

For CAS2, we make three main requests for prison data

* Probation Offender Search - called with `nomsNumber` - locally, this is entirely stubbed in wiremock in this tools repo
* Prison API - called with `nomsNumber` - locally, we talk to the `prison-api` container, so we rely on [data seeded in that.](https://github.com/ministryofjustice/prison-api/blob/37b7392bc69960f159de27e72aee19a9ae7e6ad5/src/main/resources/db/migration/data/R__1_15__OFFENDERS.sql#L26)
* Delius - 
  * [`approved-premises-and-delius`, the repo created for us to get Oasys reports](https://github.com/ministryofjustice/hmpps-probation-integration-services/blob/main/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt#L14) - called with `crn`. I think we are mocking some of these endpoints via the `ApAndOasys` files in the `mappings` folder.
  * `ApDeliusContext` - called with `crn` - I'm not entirely sure how this works,  but we are mocking some of these endpoints via the `ApDeliusContext` files in the `mappings` folder.
