### PR TITLE
Improve README & rename APPROVED_PREMISES_API_PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /community-api-db
 /Brewfile.lock.json
 /hmpps-probation-integration-services
+package-lock.json
+.idea
+.DS_STORE

--- a/bin/start-server
+++ b/bin/start-server
@@ -11,15 +11,15 @@ while [ "$1" != "" ];
 do
    case $1 in
     --local-ui)
-        if [ -z "${APPROVED_PREMISES_UI_PATH}" ]; then
-          echo "Path to local UI not found, please ensure you have set the APPROVED_PREMISES_UI_PATH environment variable and try again"
+        if [ -z "${LOCAL_CAS_UI_PATH}" ]; then
+          echo "Path to local UI not found, please ensure you have set the LOCAL_CAS_UI_PATH environment variable and try again"
           exit 1
         fi
         args="$args --local-ui"
         ;;
     --local-api)
-        if [ -z "${APPROVED_PREMISES_API_PATH}" ]; then
-          echo "Path to local API not found, please ensure you have set the APPROVED_PREMISES_API_PATH environment variable and try again"
+        if [ -z "${LOCAL_CAS_API_PATH}" ]; then
+          echo "Path to local API not found, please ensure you have set the LOCAL_CAS_API_PATH environment variable and try again"
           exit 1
         fi
         args="$args --local-api"
@@ -62,12 +62,11 @@ until curl http://localhost:9590/api/health > /dev/null 2>&1; do
 done
 
 echo ""
-echo "Stack running! You will be able to log into the application at http://localhost:3000 with the following Delius user:"
+echo "Stack running! You will be able to log into the application at http://localhost:3000:"
 echo ""
-echo "Username: JIMSNOWLDAP"
-echo "Password: secret"
+echo "For CAS1 and CAS3 use the Delius user JIMSNOWLDAP/secret"
 echo ""
-echo "or Nomis user: POM_USER/password123456"
+echo "For CAS2, use the Nomis user: POM_USER/password123456"
 echo ""
 echo "  also: - external CAS2_ASSESSOR_USER/password123456 (ROLE_CAS2_ASSESSOR)"
 echo "        - Nomis user CAS2_MI_USER/password123456 (ROLE_CAS2_MI)"

--- a/bin/utils/install-dependencies.sh
+++ b/bin/utils/install-dependencies.sh
@@ -6,3 +6,5 @@ then
   cd "$(dirname "$0")/../.." || exit
   brew bundle > /dev/null 2>&1
 fi
+
+echo "Dependencies installed"

--- a/bin/utils/launch-docker.sh
+++ b/bin/utils/launch-docker.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+echo "Checking if Docker is running"
+
 if (! docker stats --no-stream > /dev/null 2>&1  ); then
   echo "==> Launching Docker..."
 
@@ -13,3 +15,5 @@ while (! docker stats --no-stream > /dev/null 2>&1 ); do
   sleep 1
 done
 fi
+
+echo "Docker is running"

--- a/tiltfile
+++ b/tiltfile
@@ -32,7 +32,7 @@ if local_api:
         "local_api",
         serve_cmd="./gradlew bootRunLocal",
         resource_deps=["database", "redis", "hmpps-auth", "approved-premises-and-delius"],
-        serve_dir=os.getenv("APPROVED_PREMISES_API_PATH"),
+        serve_dir=os.getenv("LOCAL_CAS_API_PATH"),
         readiness_probe=probe(
             period_secs=15, http_get=http_get_action(port=8080, path="/health")
         ),
@@ -53,8 +53,8 @@ if local_ui:
         "local_ui",
         cmd="npm install",
         serve_cmd="npm run start:dev",
-        serve_dir=os.getenv("APPROVED_PREMISES_UI_PATH"),
-        dir=os.getenv("APPROVED_PREMISES_UI_PATH"),
+        serve_dir=os.getenv("LOCAL_CAS_UI_PATH"),
+        dir=os.getenv("LOCAL_CAS_UI_PATH"),
         resource_deps=["hmpps-auth"],
         readiness_probe=probe(
             period_secs=15, http_get=http_get_action(port=3000, path="/health")
@@ -64,6 +64,7 @@ if local_ui:
             "HMPPS_AUTH_URL": "http://localhost:9091/auth",
             "HMPPS_AUTH_EXTERNAL_URL": "http://localhost:9091/auth",
             "TOKEN_VERIFICATION_API_URL": "http://localhost:9091/verification",
+            "PROVIDE_PERFORMANCE_HUB_REPORTS": "true",
         }
     )
     resources.append("local_ui")


### PR DESCRIPTION
This commit refreshes the README to better reflect how the tools are typically used and provide instructions in a logical order.

This commit refreshes the README to better reflect how the tools are typically used and provide instructions in a logical order.

It also renames some env vars to reflect that they’re used for all CASs:

APPROVED_PREMISES_API_PATH becomes LOCAL_CAS_API_PATH

APPROVED_PREMISES_UI_PATH becomes LOCAL_CAS_UI_PATH