### PR TITLE
CAS1 Seeding: add Delius user for CAS1 'CRU Member' persona

### DIFF
--- a/seed/community-api/V99_3__regions_and_staff.sql
+++ b/seed/community-api/V99_3__regions_and_staff.sql
@@ -16,6 +16,11 @@ values
 
 --- we update jim snow to use a probation area id we have configured in the system (N58, South West)
 UPDATE STAFF set probation_area_id = (SELECT probation_area_id FROM PROBATION_AREA WHERE CODE = 'N58') WHERE staff_id = '17';
+
+--- we update SheilaHancockNPS to use a probation area id we have configured in the system (N58, South West)
+---   we're using Sheila as the CAS1 user E2E user for the "CRU Member" persona
+UPDATE STAFF set probation_area_id = (SELECT probation_area_id FROM PROBATION_AREA WHERE CODE = 'N58'), FORENAME = 'E2E', FORENAME2 = '', SURNAME = 'CRU Member' WHERE staff_id = '11';
+
 --- we update bernard beaks to use a probation area id we have configured in the system (N58, South West)
 UPDATE STAFF set probation_area_id = (SELECT probation_area_id FROM PROBATION_AREA WHERE CODE = 'N58'), FORENAME = 'bernard', SURNAME = 'beaks' WHERE staff_id = '2500057096';
 --- we update PANESAR.JASPAL to use a probation area id we have configured in the system (N03, Wales)

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_SheilaHancockNPS.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_SheilaHancockNPS.json
@@ -1,0 +1,24 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPattern": "/user/SHEILAHANCOCKNPS"
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "jsonBody": {
+      "userId": 11,
+      "username": "SHEILAHANCOCKNPS",
+      "firstName": "E2E",
+      "surname": "CRU Member",
+      "email": "e2e.cru.member@example.justice.gov.uk",
+      "enabled": true,
+      "roles": ["ROLE_PROBATION"]
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "X-comment": "the CAS1 E2E user for the 'CRU Team' persona (CAS1_E2E_CRU_MEMBER_USERNAME)"
+    }
+  }
+}


### PR DESCRIPTION
We use the existing [SheilaHancockNPS user][] defined in CommunityAPI's LDAP seeding.

And we [adjust the staff entry][] which corresponds to this user to set a probation area and set a name of 'E2E CRU Member'.

[SheilaHancockNPS user]:
https://github.com/ministryofjustice/community-api/blob/736ac63ff7705a0c8d998ed2773d59563b0fdea4/src/main/resources/schema.ldif#L137C1-L148C21

[adjust the staff entry]:
https://github.com/ministryofjustice/community-api/blob/736ac63ff7705a0c8d998ed2773d59563b0fdea4/src/main/resources/db/data/V1_4__offenders_licences_data.sql#L12C1-L15C1

See also related PRs:

- UI: https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1902
- API: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1978