### PR TITLE
Make HMPPS-Auth to Delius /user/* stubs case-sensitive

### DIFF
--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_ApprovedPremisesTestUser.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_ApprovedPremisesTestUser.json
@@ -2,7 +2,7 @@
   "priority": 2,
   "request": {
     "method": "GET",
-    "urlPathPattern": "/user/APPROVEDPREMISESTESTUSER"
+    "urlPathPattern": "(?i)\/user\/APPROVEDPREMISESTESTUSER"
   },
   "response": {
     "transformers": ["response-template"],

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_BernardBeaks.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_BernardBeaks.json
@@ -2,7 +2,7 @@
   "priority": 2,
   "request": {
     "method": "GET",
-    "urlPattern": "/user/BERNARD.BEAKS"
+    "urlPattern": "(?i)\/user\/BERNARD.BEAKS"
   },
   "response": {
     "transformers": ["response-template"],

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_JimSnow.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_JimSnow.json
@@ -2,7 +2,7 @@
   "priority": 2,
   "request": {
     "method": "GET",
-    "urlPattern": "/user/JIMSNOWLDAP"
+    "urlPattern": "(?i)\/user\/JIMSNOWLDAP"
   },
   "response": {
     "transformers": ["response-template"],

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_NonStaffUser.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_NonStaffUser.json
@@ -2,7 +2,7 @@
   "priority": 2,
   "request": {
     "method": "GET",
-    "urlPattern": "/user/NONSTAFFUSER"
+    "urlPattern": "(?i)\/user\/NONSTAFFUSER"
   },
   "response": {
     "transformers": ["response-template"],

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_SheilaHancockNPS.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_SheilaHancockNPS.json
@@ -2,7 +2,7 @@
   "priority": 2,
   "request": {
     "method": "GET",
-    "urlPattern": "/user/SHEILAHANCOCKNPS"
+    "urlPattern": "(?i)\/user\/SHEILAHANCOCKNPS"
   },
   "response": {
     "transformers": ["response-template"],


### PR DESCRIPTION
When logging in to HMPPS-Auth the username can be supplied in any case. With this commit we make our stubs case-insensitive also so that local development and local E2E tests benefit from the same behaviour.

[Issue 512][] on the Wiremock repo revealed that the use of "embedded flags" is supported. This works in the `urlPattern` matcher as well as for the illustrated `queryParameters`.

[Issue 512][]:
https://github.com/wiremock/wiremock/issues/512#issuecomment-291535632