### PR TITLE
Remove Assess-Risks-And-Needs: unused

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,18 +111,6 @@ services:
       - SPRING_FLYWAY_LOCATIONS=classpath:/db/schema,classpath:/db/data,filesystem:/seed
       - ALFRESCO_BASEURL=http://wiremock:8080/alfresco
 
-  hmpps-assess-risks-and-needs:
-    image: quay.io/hmpps/hmpps-assess-risks-and-needs
-    container_name: assess-risks-and-needs
-    ports:
-      - "9580:8080"
-    environment:
-      - SERVER_PORT=8080
-      - SPRING_PROFILES_ACTIVE=oasys-rsr,dev
-      - OAUTH_ENDPOINT_URL=http://hmpps-auth:8080/auth
-      - ASSESSMENT-API_BASE-URL=http://wiremock:8080
-      - COMMUNITY-API_BASE-URL=http://community-api:8080
-
   wiremock:
     image: wiremock/wiremock
     container_name: wiremock

--- a/tiltfile
+++ b/tiltfile
@@ -17,7 +17,6 @@ resources = [
     "auth-db",
     "hmpps-auth",
     "community-api",
-    "hmpps-assess-risks-and-needs",
     "wiremock",
     "database",
     "prison-api",


### PR DESCRIPTION
Previously (a long time ago) we used to retrieve the risk ratings used to 
build the sidebar widget from ARN.

To avoid the possibility of having mismatched
risk information from both OASys and ARNs we
switched to obtaining the risk ratings from
OASys. See: 

`wiremock/mappings/ApAndOasys_GetRoshRiskRatings.json`