### PR TITLE
Change hmpps-manage-users-api healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,7 @@ services:
       ports:
         - "9560:8096"
       healthcheck:
-        test: [ "CMD", "curl", "-f", "http://localhost:8096/health" ]
+        test: [ "CMD", "curl", "-f", "http://localhost:8096/health/ping" ]
       environment:
         - SERVER_PORT=8096
         - HMPPS_AUTH_ENDPOINT_URL=http://hmpps-auth:8080/auth


### PR DESCRIPTION
The fully featured health check we were previously using on http://localhost:8096/health fails because we don’t have an instance of the delius api deployed locally (nor do we need one).

To avoid this service appearing in an unhealth state in tilt, this commit changes to the use simpler and more shallow health check available on http://localhost:8096/health/ping