### PR TITLE
APS-1292 - Move DBs into one folder, simplifying clear down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 package-lock.json
 .idea
 .DS_STORE
+databases/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The tool can run the CAS UIs and API using the locally checked out code, instead
 
 This is typically how the tool is used during development as you can quickly redeploy changes made locally for testing.
 
-To support this, clone the API project and required UI projects e.g.
+To support this, clone the API project and required UI project(s) e.g.
 
 * https://github.com/ministryofjustice/hmpps-approved-premises-api
 * https://github.com/ministryofjustice/hmpps-approved-premises-ui
@@ -92,7 +92,7 @@ ap-tools server stop
 Note that by default the API database will be retained across stop/start. If you'd like to remove this database, run the following from the root of the project 
 
 ```bash
-docker compose down -v
+docker compose down --clear-databases
 ```
 
 ### Restart/Refresh components
@@ -103,21 +103,20 @@ If you start ap-tools using '--local-ui', any changes you make to your ui code s
 
 If you start ap-tools using '--local-api', you will need to manually restart the 'local-api' component in tilt via the [tilt console](http://localhost:10350).
 
-#### Refresh Docker Components
+#### Refresh 3rd Party Components & Databases
 
-If you'd like to refresh docker containers to use their latest version, you can use
+When compose is started all docker containers wll be updated automatically, therefore, stop/starting ap-tools will refresh all containers
+
+If you want to refresh already running containers, use the --refresh option
 
 ```bash
-ap-tools server start --refresh
+ap-tools server stop --refresh
 ```
 
-Note - this _will not_ refresh the approved-premises-and-delius component, as this is run locally via gradle
-
-If you'd like to restart the entire tilt stack and remove the API databases, you can use the following script from the root of the project
+If you'd like to restart the entire stack and remove all databases (including the API database), you can use the following script from the root of the project
 
 ```bash
-ap-tools server stop                                       
-docker compose down -v
+ap-tools server stop --clear-databases     
 ap-tools server start --local-ui --local-api
 ```
 
@@ -135,8 +134,6 @@ We login to CAS1 and CAS3 Systems using delius credentials. Anything can be used
  * NONSTAFFUSER - user that is not staff. shouldn't be allowed access
  * LAOFULLACCESS - user that has whitelisted (exclusion) for X400000
  * LAORESTRICTED - user that is blacklisted (restriction) for X400000
- * ApprovedPremisesTestUser - user for "Future manager" persona in E2E tests
- * SheilaHancockNPS - user for the "CRU member" persona in E2E tests
 
 ### CAS2
 

--- a/bin/server
+++ b/bin/server
@@ -18,7 +18,7 @@ fi
 if [ "$command" = "start" ]; then
   "$(dirname "$0")/start-server" "$@"
 elif [ "$command" = "stop" ]; then
-  "$(dirname "$0")/stop-server"
+  "$(dirname "$0")/stop-server" "$@"
 else
   echo "Unknown command $command"
   exit 1

--- a/bin/start-server
+++ b/bin/start-server
@@ -6,6 +6,7 @@ args=""
 
 do_update=1
 do_refresh=0
+script_dir=$(dirname "$0")
 
 while [ "$1" != "" ];
 do
@@ -35,20 +36,22 @@ do
 done
 
 if [ $do_update -gt 0 ]; then
-  if "$(dirname "$0")/utils/check-for-update.sh"; then
+  if "$script_dir/utils/check-for-update.sh"; then
     do_refresh=1
   fi
 fi
 
 if [ $do_refresh -gt 0 ]; then
-  "$(dirname "$0")/utils/refresh-containers.sh"
+  "$script_dir/utils/refresh-containers.sh"
 fi
 
-"$(dirname "$0")/utils/install-or-update-integration-services.sh"
+"$script_dir/utils/install-or-update-integration-services.sh"
 
 echo "Starting the Approved Premises Stack. This might take a moment. Logs available at http://localhost:10350"
 
-cmd="tilt up -f $(dirname "$0")/../tiltfile"
+mkdir -p "$script_dir"/../databases
+
+cmd="tilt up -f $script_dir/../tiltfile"
 
 if [ ${#args} -ge 0 ]; then
   cmd="$cmd -- $args"
@@ -56,13 +59,14 @@ fi
 
 $cmd > /dev/null 2>&1 &
 
-until curl http://localhost:9590/api/health > /dev/null 2>&1; do
+echo "Waiting for approved-premises-api to be healthy"
+until curl http://localhost:8080/api/health > /dev/null 2>&1; do
   printf '.'
   sleep 2
 done
 
 echo ""
-echo "Stack running! You will be able to log into the application at http://localhost:3000:"
+echo "Stack running! You will be able to log into the application at http://localhost:3000"
 echo ""
 echo "For CAS1 and CAS3 use the Delius users. Any password can be used."
 echo ""
@@ -71,7 +75,6 @@ echo "   NONSTAFFUSER - user that is not staff"
 echo "   LAOFULLACCESS - user that has whitelisted (exclusion) for X400000"
 echo "   LAORESTRICTED - user that is blacklisted (restriction) for X400000"
 echo "   ApprovedPremisesTestUser - used for 'Future manager' persona in E2E tests"
-echo '   SheilaHancockNPS - user for the 'CRU member' persona in E2E tests'
 echo ""
 echo "For CAS2, use the Nomis users"
 echo ""

--- a/bin/stop-server
+++ b/bin/stop-server
@@ -1,3 +1,23 @@
 #!/bin/sh
 
-killall tilt && tilt down -f "$(dirname "$0")/../tiltfile"
+do_clear_databases=0
+script_dir=$(dirname "$0")
+
+while [ "$1" != "" ];
+do
+   case $1 in
+    --clear-databases)
+        do_clear_databases=1
+        ;;
+  esac
+  shift
+done
+
+echo "==> Stopping tilt..."
+
+killall tilt && tilt down -f "$script_dir/../tiltfile"
+
+if [ $do_clear_databases -gt 0 ]; then
+  "$script_dir/utils/clear-databases.sh"
+fi
+

--- a/bin/utils/clear-databases.sh
+++ b/bin/utils/clear-databases.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo "==> Clearing databases..."
+
+rootpath="$(dirname "$0")/../../"
+rm -rf "$rootpath/databases"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - APPROVED_PREMISES_API_URL=http://host.docker.internal:8080
       - INGRESS_URL=http://localhost:3000
     ports:
-      - 3000:3000
+      - "3000:3000"
     entrypoint: "node dist/server.js | bunyan"
 
   database:
@@ -63,7 +63,7 @@ services:
       - POSTGRES_PASSWORD=localdev_password
       - POSTGRES_DB=approved_premises_localdev
     volumes:
-      - database-data-development:/var/lib/postgresql/data/
+      - ./databases/api-db:/var/lib/postgresql/data/
     ports:
       - "5431:5432"
     healthcheck:
@@ -106,7 +106,7 @@ services:
       - "9590:8080"
     volumes:
       - ./seed/community-api:/seed
-      - ./community-api-db:/community-api-db
+      - ./databases/community-api-db:/community-api-db
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
@@ -144,7 +144,7 @@ services:
       - SPRING_FLYWAY_LOCATIONS=classpath:/db/migration/nomis/ddl,classpath:/db/migration/data,classpath:/db/migration/nomis/data,classpath:/db/migration/nomis/data-hsqldb,filesystem:/seed
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://hmpps-auth:8080/auth/.well-known/jwks.json
     volumes:
-      - ./nomis-db:/nomis-db
+      - ./databases/nomis-db:/nomis-db
       - ./seed/prison-api:/seed
 
   nomis-user-roles-api:

--- a/tiltfile
+++ b/tiltfile
@@ -85,7 +85,8 @@ local_resource(
         "OAUTH2_CLIENT-SECRET": "clientsecret",
         "SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_HMPPS-AUTH_TOKEN-URI": "http://localhost:9091/auth/oauth/token",
         "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI": "http://localhost:9091/auth/.well-known/jwks.json",
-        "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI": "http://localhost:9091/auth/issuer"
+        "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI": "http://localhost:9091/auth/issuer",
+        "SPRING_DATASOURCE_URL": "jdbc:h2:file:" + config.main_dir + "/databases/approved-premises-and-delius-db/dev;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092"
     },
 )
 


### PR DESCRIPTION
This commit moves all database files into a top-level 'databases' folder. It also adds a 'clear-databases' option when stopping ap-tools to clear all databases, including the API database. This simplifies database management and removes the need to run an additional delete volumes command to clear databases.

This commit also improves the health check when starting ap-tools to use the API healthcheck endpoint instead of community api.