### PR TITLE
Use docker volume for postgres

### DIFF
--- a/bin/start-server
+++ b/bin/start-server
@@ -57,7 +57,7 @@ if [ ${#args} -ge 0 ]; then
   cmd="$cmd -- $args"
 fi
 
-$cmd > /dev/null 2>&1 &
+$cmd 2>&1 >/dev/null &
 
 echo "Waiting for approved-premises-api to be healthy"
 until curl http://localhost:8080/api/health > /dev/null 2>&1; do

--- a/bin/stop-server
+++ b/bin/stop-server
@@ -15,9 +15,11 @@ done
 
 echo "==> Stopping tilt..."
 
-killall tilt && tilt down -f "$script_dir/../tiltfile"
+tilt down -f "$script_dir/../tiltfile"
+killall tilt
 
 if [ $do_clear_databases -gt 0 ]; then
+  sleep 5
+  
   "$script_dir/utils/clear-databases.sh"
 fi
-

--- a/bin/utils/clear-databases.sh
+++ b/bin/utils/clear-databases.sh
@@ -4,3 +4,5 @@ echo "==> Clearing databases..."
 
 rootpath="$(dirname "$0")/../../"
 rm -rf "$rootpath/databases"
+
+docker compose -f "$rootpath/docker-compose.yml" down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,14 +63,15 @@ services:
       - POSTGRES_PASSWORD=localdev_password
       - POSTGRES_DB=approved_premises_localdev
     volumes:
-      - ./databases/api-db:/var/lib/postgresql/data/
+      # We use a docker managed volume instead of a mapped volume (e.g. 'databases/api') before the
+      # mapped volumes are very slow meaning from scratch postgres startup is taking a very long time
+      # This coupled with the fact that when using --local-api tilt will only check if postgres is running (not ready)
+      # before starting the API is leading to start up failures
+      - database-data-api:/var/lib/postgresql/data/
     ports:
       - "5431:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+      test: pg_isready -U localdev -d approved_premises_localdev
 
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest
@@ -250,4 +251,4 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
 volumes:
-  database-data-development:
+  database-data-api:

--- a/tiltfile
+++ b/tiltfile
@@ -30,6 +30,9 @@ if local_api:
     local_resource(
         "local_api",
         serve_cmd="./gradlew bootRunLocal",
+        # Note! These checks only wait for containers to start, ideally we'd wait for them to be ready
+        # see https://docs.tilt.dev/resource_dependencies.html
+        # "For dc_resource: the container is started (NB: Tilt doesn’t currently observe docker-compose health checks)"
         resource_deps=["database", "redis", "hmpps-auth", "approved-premises-and-delius"],
         serve_dir=os.getenv("LOCAL_CAS_API_PATH"),
         readiness_probe=probe(


### PR DESCRIPTION
Docker performance when writing to a mapped folder is proving to be poor when used for postgres (e.g. over 1 minute to start from scratch vs 10 seconds if using a docker managed volume).

This coupled with the fact that when using --local-api tilt will only check if postgres is running (not ready) before starting the API is leading to start ups failing

This commit looks to provide stability by:

* Using a docker managed volume for postgres data (as was the case before the previous commit that instead mapped the data to ‘databases/api’
* Update —clear-databases option on stop to also delete docker managed volumes
* Show STDERR messages when starting tilt
* Add a pause between tilt stopping and clearing databases (if required) to ensure that probation-integration has enough time to unlock its H2 database
* Adds misc. notes in the configuration to explain why things are done this way
* Improve the postgres ready check

It’s probably worth looking at using docker managed volumes for all databases for perforamnce reasons instead of mapped folders