### PR TITLE
Rename ‘nomis-db’ folder to ‘prison-api’

### DIFF
--- a/bin/utils/refresh-containers.sh
+++ b/bin/utils/refresh-containers.sh
@@ -6,6 +6,3 @@ echo "==> Refreshing containers..."
 
 yq '.services[].image' "$(dirname "$0")/../../docker-compose.yml" | while read -r container; do docker pull "$container"; done
 
-rootpath="$(dirname "$0")/../../"
-rm -rf "$rootpath/community-api-db" && \
-rm -rf "$rootpath/nomis-db"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
       - SPRING_FLYWAY_LOCATIONS=classpath:/db/migration/nomis/ddl,classpath:/db/migration/data,classpath:/db/migration/nomis/data,classpath:/db/migration/nomis/data-hsqldb,filesystem:/seed
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://hmpps-auth:8080/auth/.well-known/jwks.json
     volumes:
-      - ./databases/nomis-db:/nomis-db
+      - ./databases/prison-api:/nomis-db
       - ./seed/prison-api:/seed
 
   nomis-user-roles-api:


### PR DESCRIPTION
nomis-db is technically correct, but prison-api more user friendly when trying to figure out which database to clear for prison-api