### PR TITLE
Make api config comprehensive & add test users

### DIFF
--- a/.env.local.api-docker
+++ b/.env.local.api-docker
@@ -1,9 +1,25 @@
 SPRING_PROFILES_ACTIVE=local
+
 SPRING_DATASOURCE_URL=jdbc:postgresql://database/approved_premises_localdev
+SPRING_DATASOURCE_USERNAME=localdev
+SPRING_DATASOURCE_PASSWORD=localdev_password
+
 SPRING_DATA_REDIS_HOST=redis
 SPRING_DATA_REDIS_PORT=6379
-HMPPS_SQS_LOCALSTACKURL=http://approved-premises-api-localstack:4566
+
+SPRING_FLYWAY_LOCATIONS=classpath:db/migration/all,classpath:db/migration/local+dev+test,classpath:db/migration/local,classpath:db/migration/all-except-integration
+
 SEED_FILE-PREFIX=/tmp/seed
+SEED_AUTO_ENABLED=true
+SEED_AUTO_FILE-PREFIXES=classpath:db/seed/local+dev+test
+SEED_AUTO-SCRIPT_CAS1-ENABLED=true
+SEED_AUTO-SCRIPT_CAS2-ENABLED=true
+SEED_AUTO-SCRIPT_NOMS=A1234AI
+SEED_AUTO-SCRIPT_PRISON-CODE=LEI
+
+HMPPS_SQS_PROVIDER=localstack
+HMPPS_SQS_LOCALSTACKURL=http://approved-premises-api-localstack:4566
+HMPSS_SQS_TOPICS_DOMAIN_EVENTS_ARN=arn:aws:sns:eu-west-2:000000000000:domainevents
 
 HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
 

--- a/.env.local.api-gradle
+++ b/.env.local.api-gradle
@@ -1,9 +1,25 @@
 SPRING_PROFILES_ACTIVE=local
+
 SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5431/approved_premises_localdev
+SPRING_DATASOURCE_USERNAME=localdev
+SPRING_DATASOURCE_PASSWORD=localdev_password
+
 SPRING_DATA_REDIS_HOST=localhost
 SPRING_DATA_REDIS_PORT=6379
+
+SPRING_FLYWAY_LOCATIONS=classpath:db/migration/all,classpath:db/migration/local+dev+test,classpath:db/migration/local,classpath:db/migration/all-except-integration
+
+SEED_FILE-PREFIX=/tmp/seed
+SEED_AUTO_ENABLED=true
+SEED_AUTO_FILE-PREFIXES=classpath:db/seed/local+dev+test
+SEED_AUTO-SCRIPT_CAS1-ENABLED=true
+SEED_AUTO-SCRIPT_CAS2-ENABLED=true
+SEED_AUTO-SCRIPT_NOMS=A1234AI
+SEED_AUTO-SCRIPT_PRISON-CODE=LEI
+
+HMPPS_SQS_PROVIDER=localstack
 HMPPS_SQS_LOCALSTACKURL=http://localhost:4566
-SEED_FILE-PREFIX=./seed
+HMPSS_SQS_TOPICS_DOMAIN_EVENTS_ARN=arn:aws:sns:eu-west-2:000000000000:domainevents
 
 HMPPS_AUTH_URL=http://localhost:9091/auth
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - redis
       - hmpps-auth
     env_file:
-      - .env.api.docker
+      - .env.local.api-docker
     ports:
       - "8080:8080"
 

--- a/tiltfile
+++ b/tiltfile
@@ -39,7 +39,7 @@ if local_api:
             period_secs=15, http_get=http_get_action(port=8080, path="/health")
         ),
         serve_env={
-            "BOOT_RUN_ENV_FILE": os.getcwd() + '/.env.api.gradle'
+            "BOOT_RUN_ENV_FILE": os.getcwd() + '/.env.local.api-gradle'
         }
     )
     resources.append("local_api")

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_1.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_1.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPattern": "(?i)\/user\/AP_USER_TEST_1"
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "jsonBody": {
+      "userId": 2500077027,
+      "username": "AP_USER_TEST_1",
+      "firstName": "AP_USER",
+      "surname": "TEST_1",
+      "email": "jim.snow@example.digital.justice.gov.uk",
+      "enabled": true,
+      "roles": ["ROLE_PROBATION"]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_2.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_2.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPattern": "(?i)\/user\/AP_USER_TEST_2"
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "jsonBody": {
+      "userId": 2500077027,
+      "username": "AP_USER_TEST_2",
+      "firstName": "AP_USER",
+      "surname": "TEST_2",
+      "email": "jim.snow@example.digital.justice.gov.uk",
+      "enabled": true,
+      "roles": ["ROLE_PROBATION"]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_3.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_3.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPattern": "(?i)\/user\/AP_USER_TEST_3"
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "jsonBody": {
+      "userId": 2500077027,
+      "username": "AP_USER_TEST_3",
+      "firstName": "AP_USER",
+      "surname": "TEST_3",
+      "email": "jim.snow@example.digital.justice.gov.uk",
+      "enabled": true,
+      "roles": ["ROLE_PROBATION"]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_4.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_4.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPattern": "(?i)\/user\/AP_USER_TEST_4"
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "jsonBody": {
+      "userId": 2500077027,
+      "username": "AP_USER_TEST_4",
+      "firstName": "AP_USER",
+      "surname": "TEST_4",
+      "email": "jim.snow@example.digital.justice.gov.uk",
+      "enabled": true,
+      "roles": ["ROLE_PROBATION"]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_5.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_AP_USER_TEST_5.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPattern": "(?i)\/user\/AP_USER_TEST_5"
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "jsonBody": {
+      "userId": 2500077027,
+      "username": "AP_USER_TEST_5",
+      "firstName": "AP_USER",
+      "surname": "TEST_5",
+      "email": "jim.snow@example.digital.justice.gov.uk",
+      "enabled": true,
+      "roles": ["ROLE_PROBATION"]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_TEMPORARY-ACCOMMODATION-TRAINING-1.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_TEMPORARY-ACCOMMODATION-TRAINING-1.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPattern": "(?i)\/user\/TEMPORARY-ACCOMMODATION-TRAINING-1"
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "jsonBody": {
+      "userId": 2500077027,
+      "username": "TEMPORARY-ACCOMMODATION-TRAINING-1",
+      "firstName": "temporary-accommodation",
+      "surname": "training-1",
+      "email": "jim.snow@example.digital.justice.gov.uk",
+      "enabled": true,
+      "roles": ["ROLE_PROBATION"]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/HmppsAuthAndDelius_GetUser_TEMPORARY-ACCOMMODATION-TRAINING-2.json
+++ b/wiremock/mappings/HmppsAuthAndDelius_GetUser_TEMPORARY-ACCOMMODATION-TRAINING-2.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPattern": "(?i)\/user\/TEMPORARY-ACCOMMODATION-TRAINING-2"
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "jsonBody": {
+      "userId": 2500077027,
+      "username": "TEMPORARY-ACCOMMODATION-TRAINING-2",
+      "firstName": "temporary-accommodation",
+      "surname": "training-2",
+      "email": "jim.snow@example.digital.justice.gov.uk",
+      "enabled": true,
+      "roles": ["ROLE_PROBATION"]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
Before this commit we were relying on default config in the api projects application-local.yml to configure various connections details. This commit copies that config into the locally managed API config to give a more comprehensive view of the configuration being used. In time we should remove this duplication from application-local.yml

Furthermore, this commit adds some additional configuration that we’ll need to change/override if testing to upstream dev services for end to end testing

This commit also adds auth configuration for CAS1/3 dev e2e test users