### PR TITLE
Add specific OAsys and Tier response for new CRN

### DIFF
--- a/wiremock/mappings/ApAndOasys_GetNeedsDetails_Default.json
+++ b/wiremock/mappings/ApAndOasys_GetNeedsDetails_Default.json
@@ -1,0 +1,61 @@
+{
+  "priority": 999,
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/needs-details/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentId": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29Z",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "lastUpdatedDate": "2022-11-29T10:37:22Z",
+      "needs": {
+        "offenceAnalysisDetails": "Analysis",
+        "emotionalIssuesDetails": "[10.9] Mr Smith told me that he was untroubled by mental health difficulties and had no history of self harm or suicidal thoughts",
+        "drugIssuesDetails":  "[8.9] Mr Smith told me that he had experimented with many drugs throughout his teens. ...",
+        "alcoholIssuesDetails": "[9.9] Mr Smith told me that he rarely consumes alcohol and has not had any problems associated with excessive drinking in years...",
+        "lifestyleIssuesDetails":  "[7.9] Mr Smith has clearly had issues concerning the company he keeps, in that his involvement in the drug culture has at times been entrenched...",
+        "relationshipIssuesDetails": "[6.9] Mr Smith described his family as travellers.  He said that they were very supportive of him, although they had at times found it difficult to accept his involvement with drugs...",
+        "financeIssuesDetails":  "[5.9] Mr Smith was in receipt of Job Seekers Allowance prior to his current remand in custody...",
+        "educationTrainingEmploymentIssuesDetails": "[4.9] He said that he has since learnt to read and write during periods of custody and an initial assessment of his...",
+        "accommodationIssuesDetails":  "[3.9] Mr Smith told me that he was renting a room in a shared house, prior to his current remand...",
+        "attitudeIssuesDetails": "[12.9] During interview, Mr Smith referred to being motivated to alter his....",
+        "thinkingBehaviouralIssuesDetails":  "[11.9] The circumstances of the current offence suggest that Mr Smith acted ..."
+      },
+      "linksToHarm": {
+        "accommodationLinkedToHarm":  true,
+        "educationTrainingEmploymentLinkedToHarm": true,
+        "financeLinkedToHarm":  false,
+        "relationshipLinkedToHarm": false,
+        "lifestyleLinkedToHarm":  false,
+        "drugLinkedToHarm": false,
+        "alcoholLinkedToHarm":  false,
+        "emotionalLinkedToHarm": false,
+        "thinkingBehaviouralLinkedToHarm":  false,
+        "attitudeLinkedToHarm": false
+      },
+      "linksToReOffending": {
+        "accommodationLinkedToReOffending": true,
+        "educationTrainingEmploymentLinkedToReOffending":true,
+        "financeLinkedToReOffending": false,
+        "relationshipLinkedToReOffending":false,
+        "lifestyleLinkedToReOffending": false,
+        "drugLinkedToReOffending":false,
+        "alcoholLinkedToReOffending": true,
+        "emotionalLinkedToReOffending":false,
+        "thinkingBehaviouralLinkedToReOffending": false,
+        "attitudeLinkedToReOffending": false
+      }
+    }
+  }
+}

--- a/wiremock/mappings/ApAndOasys_GetNeedsDetails_S517283.json
+++ b/wiremock/mappings/ApAndOasys_GetNeedsDetails_S517283.json
@@ -1,8 +1,7 @@
 {
-  "id": "ad9834de-3c9b-4de7-bacf-49f3e984704f",
   "request": {
     "method": "GET",
-    "urlPathPattern": "/needs-details/(.*)"
+    "urlPathPattern": "/needs-details/S517283"
   },
   "response": {
     "headers": {
@@ -33,8 +32,8 @@
         "thinkingBehaviouralIssuesDetails":  "[11.9] The circumstances of the current offence suggest that Mr Smith acted ..."
       },
       "linksToHarm": {
-        "accommodationLinkedToHarm":  true,
-        "educationTrainingEmploymentLinkedToHarm": true,
+        "accommodationLinkedToHarm":  false,
+        "educationTrainingEmploymentLinkedToHarm": false,
         "financeLinkedToHarm":  false,
         "relationshipLinkedToHarm": false,
         "lifestyleLinkedToHarm":  false,
@@ -49,10 +48,10 @@
         "educationTrainingEmploymentLinkedToReOffending":true,
         "financeLinkedToReOffending": false,
         "relationshipLinkedToReOffending":false,
-        "lifestyleLinkedToReOffending": false,
-        "drugLinkedToReOffending":false,
+        "lifestyleLinkedToReOffending": true,
+        "drugLinkedToReOffending":true,
         "alcoholLinkedToReOffending": true,
-        "emotionalLinkedToReOffending":false,
+        "emotionalLinkedToReOffending":true,
         "thinkingBehaviouralLinkedToReOffending": false,
         "attitudeLinkedToReOffending": false
       }

--- a/wiremock/mappings/HMPPSTier_GetTierForCrn_Default.json
+++ b/wiremock/mappings/HMPPSTier_GetTierForCrn_Default.json
@@ -1,0 +1,18 @@
+{
+  "priority": 999,
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/crn/(.*)/tier"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "tierScore": "D2",
+      "calculationId": "734996bc-ae5f-44a5-8925-3428492846c3",
+      "calculationDate": "2022-09-05T10:19:00"
+    }
+  }
+}

--- a/wiremock/mappings/HMPPSTier_GetTierForCrn_S517283.json
+++ b/wiremock/mappings/HMPPSTier_GetTierForCrn_S517283.json
@@ -1,8 +1,7 @@
 {
-  "id": "05c36ca3-f66c-4ffe-917e-65aff9567af1",
   "request": {
     "method": "GET",
-    "urlPathPattern": "/crn/(.*)/tier"
+    "urlPathPattern": "/crn/S517283/tier"
   },
   "response": {
     "headers": {
@@ -10,7 +9,7 @@
     },
     "status": 200,
     "jsonBody": {
-      "tierScore": "D2",
+      "tierScore": "A1",
       "calculationId": "734996bc-ae5f-44a5-8925-3428492846c3",
       "calculationDate": "2022-09-05T10:19:00"
     }


### PR DESCRIPTION
The crn S517283 was recently added to support local testing of the Women’s Estate functionality

This commit adds specific wiremocks for this CRN for the following:

* ApAndOasys_GetNeedsDetails -> Ensures all available checkboxes are shown, arranged under different sections compared to the default configuration
* HMPPSTier_GetTierForCrn -> Returns tier ‘A1’, meaning it’s not an exceptional case. The default tier of ‘D2’ triggers the exception case flow on the UI

![Screenshot 2024-10-04 at 10 01 01](https://github.com/user-attachments/assets/c8a4a1c3-7b07-47b1-82d7-0b590f2fdf71)
