### PR TITLE
Fix hmpps-external-users-api localstack config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,6 +183,8 @@ services:
       - SPRING_R2DBC_URL=r2dbc:postgresql://auth-db:5432/auth-db?sslmode=prefer
       - SPRING_FLYWAY_URL=jdbc:postgresql://auth-db:5432/auth-db?sslmode=prefer
       - API_BASE_URL_OAUTH=http://hmpps-auth:8080/auth
+      - HMPPS_SQS_PROVIDER=localstack
+      - HMPPS_SQS_LOCALSTACKURL=http://approved-premises-api-localstack:4566
 
   auth-db:
     image: postgres:15


### PR DESCRIPTION
hmpps-external-users-api has recently switched to using the hmpps-sqs lbrary to connect to SQS

This commit adds the configuration required for the tool to use our localstack deployemnt (config was taken from the CAS API equivalent)