### PR TITLE
Disable external-users flyway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,7 @@ services:
       - SERVER_PORT=8098
       - SPRING_PROFILES_ACTIVE=dev,local-postgres
       - SPRING_R2DBC_URL=r2dbc:postgresql://auth-db:5432/auth-db?sslmode=prefer
+      - SPRING_FLYWAY_ENABLED=false
       - SPRING_FLYWAY_URL=jdbc:postgresql://auth-db:5432/auth-db?sslmode=prefer
       - API_BASE_URL_OAUTH=http://hmpps-auth:8080/auth
       - HMPPS_SQS_PROVIDER=localstack


### PR DESCRIPTION
We have observed an issue where hmpps-external-users’ flyway configuration appears to conflict with hmpps-auth. Given that the shared database is owned by hmpps-auth, we have disabled the flyway configuration in hmpps-external-users