### PR TITLE
Add test users to hmpps-external-users-api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,6 +175,7 @@ services:
       - SPRING_FLYWAY_URL=jdbc:postgresql://auth-db-external-users:5432/auth-db?sslmode=prefer
       - API_BASE_URL_OAUTH=http://hmpps-auth:8080/auth
       - HMPPS_SQS_PROVIDER=localstack
+      - SPRING_FLYWAY_LOCATIONS=classpath:db/auth,db/dev/data/auth_{vendor},db/dev/data/auth,filesystem:/seed
       - HMPPS_SQS_LOCALSTACKURL=http://approved-premises-api-localstack:4566
 
   auth-db:


### PR DESCRIPTION
c221a93e38b770cbc22ec05477cef842cf364dc6 split the databases being used by hmpps-auth and hmpps-external-users-api. Previously they shared the same hmpps-auth managed database. This split meant our test users were not added to hmpps-external-users-api.

This commit applies the same seed jobs to the hmpps-external-users-api database, ensuring our test users also exist in that database