### PR TITLE
Enable two UIs to be run at once!

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Then add the path to these checked out projects in your ~/.zsrhc file:
 
 ```bash
 # ~/.zshrc
-export LOCAL_CAS_API_PATH=/Users/david.atkins/git-clones/hmpps-approved-premises-api
-export LOCAL_CAS_UI_PATH=/Users/david.atkins/git-clones/hmpps-approved-premises-ui
+export LOCAL_CAS_API_PATH=/Users/your-directories/hmpps-approved-premises-api
+export LOCAL_CAS_UI_PATH=/Users/your-directories/hmpps-approved-premises-ui
+export SECOND_LOCAL_CAS_UI_PATH=/Users/your-directories/hmpps-temporary-accommodation-ui
 ```
 
 Note! We currently only support running 1 UI at any time, populate LOCAL_CAS_UI_PATH with which ever you'd like to use
@@ -67,10 +68,17 @@ export PATH="$PATH:/<path-to-approved-premises-tools>/bin"
 
 ### Start ap-tools
 
-We typically run ap-tools passing in the '--local-api and --local-ui' arguments to run the locally cloned versions of the projects
+We typically run ap-tools passing in the '--local-api and --local-ui' arguments to run the locally cloned versions of the projects.
+
 
 ```bash
 ap-tools server start --local-ui --local-api
+```
+
+To run two UIs locally use the 'second ui- flag, if you do not use this flag, a second UI will not be created from the docker image. This is just for having multiple UIs working locally on your machine.
+
+```bash
+ap-tools server start --local-ui --local-api --second-local-ui
 ```
 
 If you drop the '--local-*' arguments, the most recently published docker images will be run instead.

--- a/bin/ap-tools
+++ b/bin/ap-tools
@@ -11,6 +11,7 @@ elif [ "$command" = "--help" ]; then
   echo "  server stop"
   echo "Options:"
   echo "  --local-ui"
+  echo "  --second-local-ui"
   echo "  --local-api"
   echo "  --refresh"
   echo "  --no-update"

--- a/bin/start-server
+++ b/bin/start-server
@@ -9,6 +9,7 @@ do_refresh=0
 local_ui=0
 local_api=0
 local_api_dev_upstream=0
+second_local_ui=0
 
 while [ "$1" != "" ];
 do
@@ -19,6 +20,14 @@ do
           exit 1
         fi
         local_ui=1
+        ;;
+    --second-local-ui)
+        if [ -z "${SECOND_LOCAL_CAS_UI_PATH}" ]; then
+          echo "Path to second local UI not found, please ensure you have set the SECOND_LOCAL_CAS_UI_PATH environment variable and try again"
+          exit 1
+        fi
+        echo "second local ui found"
+        second_local_ui=1
         ;;
     --local-api)
         if [ -z "${LOCAL_CAS_API_PATH}" ]; then
@@ -73,6 +82,10 @@ fi
 
 if [ $local_ui -gt 0 ]; then
   tiltArgs="$tiltArgs --local-ui"
+fi
+
+if [ $second_local_ui -gt 0 ]; then
+  tiltArgs="$tiltArgs --second-local-ui"
 fi
 
 echo "==> Starting Tilt"

--- a/tiltfile
+++ b/tiltfile
@@ -2,11 +2,13 @@ docker_compose("./docker-compose.yml")
 
 config.define_bool("local-api")
 config.define_bool("local-ui")
+config.define_bool("second-local-ui")
 
 cfg = config.parse()
 
 local_api = cfg.get("local-api", False)
 local_ui = cfg.get("local-ui", False)
+second_local_ui = cfg.get("second-local-ui", False)
 
 resources = [
     "api",
@@ -69,6 +71,27 @@ if local_ui:
         }
     )
     resources.append("local_ui")
+
+if second_local_ui:
+    local_resource(
+        "second_local_ui",
+        cmd="npm install",
+        serve_cmd="PORT=3002 npm run start:dev",
+        serve_dir=os.getenv("SECOND_LOCAL_CAS_UI_PATH"),
+        dir=os.getenv("SECOND_LOCAL_CAS_UI_PATH"),
+        resource_deps=["hmpps-auth"],
+        readiness_probe=probe(
+            period_secs=15, http_get=http_get_action(port=3002, path="/health")
+        ),
+        serve_env={
+            "APPROVED_PREMISES_API_URL": "http://localhost:8080",
+            "HMPPS_AUTH_URL": "http://localhost:9091/auth",
+            "HMPPS_AUTH_EXTERNAL_URL": "http://localhost:9091/auth",
+            "TOKEN_VERIFICATION_API_URL": "http://localhost:9091/verification",
+            "PROVIDE_PERFORMANCE_HUB_REPORTS": "true",
+        }
+    )
+    resources.append("second_local_ui")
 
 local_resource(
     "approved-premises-and-delius",


### PR DESCRIPTION
Enables two UIs to be run at once. 🙀 

With more work happening between CAS2 and 3 UIs, there has been a lot of context switching, and having to turn on an off your environments to switch them over is a right faff!

To get this working make sure you add the path to your zschr file
`export SECOND_LOCAL_CAS_UI_PATH=/Users/your-directories/hmpps-temporary-accommodation-ui`
 

I have this working locally for me, but I haven't used it in anger - so it would be grand if someone else could give this a go before being merged

