### PR TITLE
Align postgres version with production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,8 @@ services:
     entrypoint: "node dist/server.js | bunyan"
 
   database:
-    image: "postgis/postgis"
+    # we align with the version of postgres used in AWS
+    image: "postgis/postgis:14-3.5"
     container_name: approved-premises-postgres-dev
     environment:
       - JAVA_TOOL_OPTIONS=-XX:UseSVE=0
@@ -86,6 +87,7 @@ services:
       - LOGGING_LEVEL_UK_GOV_JUSTICE=debug
       - SPRING_FLYWAY_LOCATIONS=classpath:db/auth,db/dev/data/auth_{vendor},db/dev/data/auth,filesystem:/seed
       - SPRING_DATASOURCE_URL=jdbc:postgresql://auth-db:5432/auth-db
+      - MANAGE-USERS-API_ENABLED=true
 
   wiremock:
     image: wiremock/wiremock


### PR DESCRIPTION
We use a postgis docker image becuase this has the postgis extensions pre-installed (much like, RDS). The ‘vanilla’ postgres image does not have postgis extensions pre-installed.