### PR TITLE
Sync NOMS offender A1234AJ with HMPPS Probation Integration Services.

### DIFF
--- a/wiremock/mappings/noms_number_A1234AJ/ProbationOffenderSearchApi_SearchByNomsNumber.json
+++ b/wiremock/mappings/noms_number_A1234AJ/ProbationOffenderSearchApi_SearchByNomsNumber.json
@@ -35,8 +35,8 @@
         "age": "45",
         "gender": "Male",
         "currentDisposal": "1",
-        "currentExclusion": false,
-        "currentRestriction": false,
+        "currentExclusion": true,
+        "currentRestriction": true,
         "partitionArea": "some name",
         "currentTier": "UD2",
         "offenderAliases": [


### PR DESCRIPTION
In CAS2 we were seeing some weird behaviour when a POM tried to create an application for Limited Access Offender(LAO). When they started the application and entered in `A1234AJ` it would show them all the offenders details but on the "Confirm details" page where the POM actually starts the new application it would reject them and say they dont have permission.

This odd behvious was only been seen in local development. This was because the first lookup for A1234AJ was using this wiremock mock and the second one to start the actual new application was using the probation integration services and the two services were not in sync.

see
https://github.com/ministryofjustice/hmpps-probation-integration-services/blob/524e676f89c2ef7140ea5e21e7e88b85678071bb/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt#L32-L33