### PR TITLE
Clear database on stop even if tilt not running

### DIFF
--- a/bin/stop-server
+++ b/bin/stop-server
@@ -24,7 +24,7 @@ done
 echo "==> Stopping tilt..."
 
 tilt down -f "$script_dir/../tiltfile"
-killall tilt
+killall tilt || true
 
 if [ $do_clear_databases -gt 0 ]; then
   sleep 5


### PR DESCRIPTION
This change will ignore any error returned by the `killall tilt` command, which errors if there are no instances of tilt running.

This ensures that even if tilt isn’t running when the `stop` command is issued, we still clear any database volumes managed by compose.