### PR TITLE
Revise API config and document the templates

### DIFF
--- a/.env.api.template
+++ b/.env.api.template
@@ -1,4 +1,9 @@
+# This file provides the default API configuration (as environment variables)
+# It assumes that the API is being ran via gradle (e.g. --local-api)
+# Some of these values are overridden in docker-compose.yml for when running via docker.
 SPRING_PROFILES_ACTIVE=dev,debug
+
+SPRING_OUTPUT_ANSI_ENABLED=ALWAYS
 
 SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5431/approved_premises_localdev
 SPRING_DATASOURCE_USERNAME=localdev
@@ -63,3 +68,4 @@ SENTRY_ENVIRONMENT=local
 
 NOTIFY_EMAILADDRESSES_NACRO=${NOTIFY_EMAILADDRESSES_NACRO}
 
+REFRESH-INMATE-DETAILS-CACHE_LOGGING_ENABLED=true

--- a/.env.ui.template
+++ b/.env.ui.template
@@ -1,3 +1,6 @@
+# This file provides the default API configuration (as environment variables)
+# It assumes that the API is being ran via gradle (e.g. --local-ui)
+# Some of these values are overridden in docker-compose.yml for when running via docker.
 API_CLIENT_ID=${API_CLIENT_ID}
 API_CLIENT_SECRET=${API_CLIENT_SECRET}
 

--- a/bin/utils/resolve_secrets.sh
+++ b/bin/utils/resolve_secrets.sh
@@ -50,5 +50,8 @@ resolve_secrets() {
     rm -f "$target"
     # resolve 'variables' in source with env vars
     envsubst < "$source" > "$target"
+    # remove comments from the resultant file
+    # -i '' is required for mac os, see https://stackoverflow.com/questions/26081375
+    sed -i '' '/^#/d' "$target"
   )
 }


### PR DESCRIPTION
Add any configuration defined in the API local.yml into the api.template, and document the purpose of these files.

This includes an update to `resolve_secrets.sh` to remove any lines starting with a # when processing a template. This avoids issues when trying to `export` the template values as ENV VARS for npm