### PR TITLE
Use localdev profile for API

### DIFF
--- a/.env.api.template
+++ b/.env.api.template
@@ -1,7 +1,7 @@
 # This file provides the default API configuration (as environment variables)
 # It assumes that the API is being ran via gradle (e.g. --local-api)
 # Some of these values are overridden in docker-compose.yml for when running via docker.
-SPRING_PROFILES_ACTIVE=dev,debug
+SPRING_PROFILES_ACTIVE=dev,localdev
 
 SPRING_OUTPUT_ANSI_ENABLED=ALWAYS
 
@@ -13,19 +13,8 @@ SPRING_DATA_REDIS_HOST=localhost
 SPRING_DATA_REDIS_PORT=6379
 SPRING_DATA_REDIS_PASSWORD=
 
-SPRING_FLYWAY_LOCATIONS=classpath:db/migration/all,classpath:db/migration/local+dev+test,classpath:db/migration/dev,classpath:db/migration/all-except-integration
-
-SEED_FILE-PREFIX=./seed
-SEED_ON-STARTUP_ENABLED=true
-SEED_ON-STARTUP_FILE-PREFIXES=classpath:db/seed/dev+test,classpath:db/seed/local+dev+test
-SEED_ON-STARTUP_SCRIPT_CAS1-ENABLED=true
-SEED_ON-STARTUP_SCRIPT_CAS2-ENABLED=true
-SEED_ON-STARTUP_SCRIPT_NOMS=A5276DZ
-SEED_ON-STARTUP_SCRIPT_PRISON-CODE=MDI
-
 HMPPS_SQS_PROVIDER=localstack
 HMPPS_SQS_LOCALSTACKURL=http://localhost:4566
-HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN=arn:aws:sns:eu-west-2:000000000000:domainevents
 
 HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK-SET-URI=https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json
@@ -54,18 +43,6 @@ SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_HMPPS-TIER_CLIENT-SECRET=${SYSTEM_CLI
 SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_PRISONER-ALERTS-API_CLIENT-ID=${SYSTEM_CLIENT_NOMIS_ID}
 SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_PRISONER-ALERTS-API_CLIENT-SECRET=${SYSTEM_CLIENT_NOMIS_SECRET}
 
-# properties that are not defined in the default application.yml, but are required. These have been taken from helm dev configuration
-DOMAIN-EVENTS_CAS1_EMIT-ENABLED=true
-DOMAIN-EVENTS_CAS2_EMIT-ENABLED=true
-DOMAIN-EVENTS_CAS3_EMIT-ENABLED=referralSubmitted,bookingProvisionallyMade,bookingConfirmed,bookingCancelled,bookingCancelledUpdated,personArrived,personArrivedUpdated,personDeparted,personDepartureUpdated
-DOMAIN-EVENTS_CAS1_ASYNC-SAVE-ENABLED=false
-DOMAIN-EVENTS_CAS2_ASYNC-SAVE-ENABLED=false
-DOMAIN-EVENTS_CAS3_ASYNC-SAVE-ENABLED=false
-
-USER-ALLOCATIONS_RULES_ESAP-ASSESSMENTS_ALLOCATE-TO-USER=AP_USER_TEST_2
-
 SENTRY_ENVIRONMENT=local
 
 NOTIFY_EMAILADDRESSES_NACRO=${NOTIFY_EMAILADDRESSES_NACRO}
-
-REFRESH-INMATE-DETAILS-CACHE_LOGGING_ENABLED=true


### PR DESCRIPTION
This commit updates the `env.api.template` to use the `localdev` spring profile, and removes any configuration that is managed by that profile.