### PR TITLE
Specify postgres platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 databases/
 
 .env.api
+.env.ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
   database:
     # we align with the version of postgres used in AWS
     image: "postgis/postgis:14-3.5"
+    platform: linux/amd64
     container_name: approved-premises-postgres-dev
     environment:
       - JAVA_TOOL_OPTIONS=-XX:UseSVE=0


### PR DESCRIPTION
There is not a native docker image available for postgis. Where as docker would previously download and use a different platform if there is no local image provided (regardless of platform), this is no longer the case. Therefore, we explicitly specify which platform to use for postgis

i’ve also added `.env.ui` to the .gitignore to avoid accidental checkins when switching from the firebreak ap tools branch