### PR TITLE
Remove need for checked out bootstraped ui code

### DIFF
--- a/.env.cas1-ui.template
+++ b/.env.cas1-ui.template
@@ -1,0 +1,24 @@
+# This file provides the default API configuration (as environment variables)
+# It assumes that the API is being ran via gradle (e.g. --local-cas1-ui)
+# Some of these values are overridden in docker-compose.yml for when running via docker.
+APPROVED_PREMISES_API_URL=http://localhost:8080
+
+HMPPS_AUTH_EXTERNAL_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+
+API_CLIENT_ID=${API_CLIENT_ID}
+API_CLIENT_SECRET=${API_CLIENT_SECRET}
+
+SYSTEM_CLIENT_ID=${SYSTEM_CLIENT_ID}
+SYSTEM_CLIENT_SECRET=${SYSTEM_CLIENT_SECRET}
+
+REDIS_PORT=6379
+REDIS_TLS_ENABLED=false
+REDIS_AUTH_TOKEN=
+
+SESSION_SECRET=app-insecure-default-session
+NODE_ENV=development
+
+ENABLE_V2_MATCH=true
+
+INGRESS_URL=http://localhost:3000

--- a/.env.cas2-ui.template
+++ b/.env.cas2-ui.template
@@ -1,0 +1,22 @@
+# This file provides the default API configuration (as environment variables)
+# It assumes that the API is being ran via gradle (e.g. --local-cas2-ui)
+# Some of these values are overridden in docker-compose.yml for when running via docker.
+APPROVED_PREMISES_API_URL=http://localhost:8080
+
+HMPPS_AUTH_EXTERNAL_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+
+API_CLIENT_ID=${API_CLIENT_ID}
+API_CLIENT_SECRET=${API_CLIENT_SECRET}
+
+SYSTEM_CLIENT_ID=${SYSTEM_CLIENT_ID}
+SYSTEM_CLIENT_SECRET=${SYSTEM_CLIENT_SECRET}
+
+REDIS_PORT=6379
+REDIS_TLS_ENABLED=false
+REDIS_AUTH_TOKEN=
+
+SESSION_SECRET=app-insecure-default-session
+NODE_ENV=development
+
+INGRESS_URL=http://localhost:3000

--- a/.env.cas3-ui.template
+++ b/.env.cas3-ui.template
@@ -1,10 +1,13 @@
 # This file provides the default API configuration (as environment variables)
-# It assumes that the API is being ran via gradle (e.g. --local-ui)
+# It assumes that the API is being ran via gradle (e.g. --local-cas3-ui)
 # Some of these values are overridden in docker-compose.yml for when running via docker.
 APPROVED_PREMISES_API_URL=http://localhost:8080
 
 HMPPS_AUTH_EXTERNAL_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+
+API_CLIENT_ID=${API_CLIENT_ID}
+API_CLIENT_SECRET=${API_CLIENT_SECRET}
 
 SYSTEM_CLIENT_ID=${SYSTEM_CLIENT_ID}
 SYSTEM_CLIENT_SECRET=${SYSTEM_CLIENT_SECRET}
@@ -15,3 +18,5 @@ REDIS_AUTH_TOKEN=
 
 SESSION_SECRET=app-insecure-default-session
 NODE_ENV=development
+
+INGRESS_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ databases/
 
 .env.api
 .env.ui
+
+.env.cas1-ui
+.env.cas2-ui
+.env.cas3-ui

--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ For setup instructions, [click here](SETUP.md)
 
 ## Commands
 
-```ap-tools server start```
+```ap-tools server start --cas1```
+```ap-tools server start --cas2```
+```ap-tools server start --cas3```
 
-Start CAS1 UI and API  using the latest docker images. Check progress in the [tilt console](http://localhost:10350)
+The above will start the selected CAS UI and common API using the latest docker images. Check progress in the [tilt console](http://localhost:10350)
 
-```ap-tools server start --local-ui --local-api```
+```ap-tools server start --cas1 --local-ui --local-api```
 
-Start local versions of the configured CAS UI and API (see [SETUP.md](SETUP.md) for configuration). Check progress in the [tilt console](http://localhost:10350
+Start local version of the configured CAS1 UI and API. Check progress in the [tilt console](http://localhost:10350
 
 ```ap-tools server stop```
 
@@ -40,6 +42,13 @@ Stop the tools
 ```ap-tools server stop --clear-databases```
 
 Stop the tools and clear the API database
+
+Commands can be ran sequentially. E.g. to restart ap-tools and clean the database, could use
+
+```
+ap-tools server stop --clear-databases
+ap-tools server start --cas1 --local-ui --local-api
+```
 
 ## Accessing the User Interface
 
@@ -57,4 +66,5 @@ All requests to upstream services are proxied by wiremock. Mocks can be configur
 
 ## Known Limitations
 
-* The tool only supports running CAS1 UI via docker (although changing the docker image name in docker-compose.yml should work)
+* We can't run all CAS UIs concurrently because auth only supports requests from localhost:3000 (i.e. we can't run each UI in different ports)
+* We could solve this by installing a reverse proxy (such as traefik), but we'd need to configure that to optionally forward traffic to instances running in node, not docker

--- a/SETUP.md
+++ b/SETUP.md
@@ -23,8 +23,6 @@ git clone https://github.com/ministryofjustice/hmpps-approved-premises-tools.git
 
 ## Add PATH entries
 
-By default, the tool will run the CAS1 UI and CAS API using the latest available docker images.
-
 When developing we typically want to run a locally built version of the UI and/or API, allowing us to quickly deploy and test changes
 
 Clone the required project(s) e.g.
@@ -34,12 +32,14 @@ Clone the required project(s) e.g.
 * https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui
 * https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui
 
-Then add the following environment variables, along with ap-tools binary path so you can run ap tools from any directory. For LOCAL_CAS_UI_PATH choose which ever UI project you are working on
+Then add the following environment variables, along with ap-tools binary path so you can run ap tools from any directory.
 
 ```bash
 export PATH="$PATH:/<path-to-approved-premises-tools>/bin"
 export LOCAL_CAS_API_PATH=/Users/your-directories/hmpps-approved-premises-api
-export LOCAL_CAS_UI_PATH=/Users/your-directories/hmpps-approved-premises-ui
+export LOCAL_CAS1_UI_PATH=/Users/your-directories/hmpps-approved-premises-ui
+export LOCAL_CAS2_UI_PATH=/Users/your-directories/hmpps-community-accommodation-tier-2-ui
+export LOCAL_CAS3_UI_PATH=/Users/your-directories/hmpps-temporary-accommodation-ui
 ```
 
 For these to take effect, close and open your terminal application, or you can run  `source ~/.zshrc`

--- a/bin/start-server
+++ b/bin/start-server
@@ -8,31 +8,39 @@ cd "$(dirname "$0")"
 script_dir="$(pwd)"
 
 . "$script_dir"/utils/resolve_secrets.sh
-. "$script_dir"/utils/override_ui_props_with_local_ui_props.sh
 
 local_ui=0
 local_api=0
+cas1=0
+cas2=0
+cas3=0
 
 while [ "$1" != "" ];
 do
    case $1 in
     --local-ui)
-        if [ -z "${LOCAL_CAS_UI_PATH}" ]; then
-          echo "Path to local UI not found, please ensure you have set the LOCAL_CAS_UI_PATH environment variable and try again"
-          exit 1
-        fi
-        local_ui=1
-        ;;
+      local_ui=1
+      ;;
     --local-api)
-        if [ -z "${LOCAL_CAS_API_PATH}" ]; then
-          echo "Path to local API not found, please ensure you have set the LOCAL_CAS_API_PATH environment variable and try again"
-          exit 1
-        fi
-        local_api=1
-        ;;
+      local_api=1
+      ;;
+    --cas1)
+      cas1=1
+      ;;
+    --cas2)
+      cas2=1
+      ;;
+    --cas3)
+      cas3=1
+      ;;
   esac
   shift
 done
+
+if [[ ($cas1 -eq 0 ) && ($cas2 -eq 0 ) && ($cas3 -eq 0 ) ]]; then
+  echo "Must specify either --cas1, --cas2 or --cas3 on the command line"
+  exit 1
+fi
 
 echo "Starting the Approved Premises Stack. This might take a moment. Logs available at http://localhost:10350"
 
@@ -42,19 +50,62 @@ resolve_secrets "$script_dir/../.env.api.template" \
                 "hmpps-community-accommodation-dev" \
                 "${api_secret_names[@]}"
 
-ui_secret_names=("hmpps-approved-premises-ui")
-resolve_secrets "$script_dir/../.env.ui.template" \
-                "$script_dir/../.env.ui" \
+cas1_ui_secret_names=("hmpps-approved-premises-ui")
+resolve_secrets "$script_dir/../.env.cas1-ui.template" \
+                "$script_dir/../.env.cas1-ui" \
                 "hmpps-community-accommodation-dev" \
-                "${ui_secret_names[@]}"
+                "${cas1_ui_secret_names[@]}"
+
+cas2_ui_secret_names=("hmpps-community-accommodation-tier-2-ui")
+resolve_secrets "$script_dir/../.env.cas2-ui.template" \
+                "$script_dir/../.env.cas2-ui" \
+                "hmpps-community-accommodation-dev" \
+                "${cas2_ui_secret_names[@]}"
+
+cas3_ui_secret_names=("hmpps-temporary-accommodation-ui")
+resolve_secrets "$script_dir/../.env.cas3-ui.template" \
+                "$script_dir/../.env.cas3-ui" \
+                "hmpps-community-accommodation-dev" \
+                "${cas3_ui_secret_names[@]}"
 
 tiltArgs=""
+if [ $cas1 -gt 0 ]; then
+  tiltArgs="$tiltArgs --cas1"
+fi
+
+if [ $cas2 -gt 0 ]; then
+  tiltArgs="$tiltArgs --cas2"
+fi
+
+if [ $cas3 -gt 0 ]; then
+  tiltArgs="$tiltArgs --cas3"
+fi
+
 if [ $local_api -gt 0 ]; then
+  if [ -z "${LOCAL_CAS_API_PATH}" ]; then
+    echo "Path to local API not found, please ensure you have set the LOCAL_CAS_API_PATH environment variable and try again"
+    exit 1
+  fi
+
   tiltArgs="$tiltArgs --local-api"
 fi
 
 if [ $local_ui -gt 0 ]; then
-  override_ui_props_with_local_ui_props "$script_dir/../.env.ui"
+  if [ $cas1 -gt 0 ] && [ -z "${LOCAL_CAS1_UI_PATH}" ]; then
+    echo "Path to CAS1 local UI not found, please ensure you have set the LOCAL_CAS1_UI_PATH environment variable and try again"
+    exit 1
+  fi
+
+  if [ $cas2 -gt 0 ] && [ -z "${LOCAL_CAS2_UI_PATH}" ]; then
+    echo "Path to CAS2 local UI not found, please ensure you have set the LOCAL_CAS2_UI_PATH environment variable and try again"
+    exit 1
+  fi
+
+  if [ $cas3 -gt 0 ] && [ -z "${LOCAL_CAS3_UI_PATH}" ]; then
+    echo "Path to CAS3 local UI not found, please ensure you have set the LOCAL_CAS3_UI_PATH environment variable and try again"
+    exit 1
+  fi
+
   tiltArgs="$tiltArgs --local-ui"
 fi
 

--- a/bin/stop-server
+++ b/bin/stop-server
@@ -9,7 +9,9 @@ cd "$(dirname "$0")"
 script_dir="$(pwd)"
 
 touch "$script_dir/../.env.api"
-touch "$script_dir/../.env.ui"
+touch "$script_dir/../.env.cas1-ui"
+touch "$script_dir/../.env.cas2-ui"
+touch "$script_dir/../.env.cas3-ui"
 
 while [ "$1" != "" ];
 do
@@ -24,6 +26,9 @@ done
 echo "==> Stopping tilt..."
 
 tilt down -f "$script_dir/../tiltfile"
+
+# This must run cleanly (not forced) to kill any local resources
+# started by the original tilt command
 killall tilt || true
 
 if [ $do_clear_databases -gt 0 ]; then

--- a/bin/utils/override_ui_props_with_local_ui_props.sh
+++ b/bin/utils/override_ui_props_with_local_ui_props.sh
@@ -3,6 +3,11 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
+#
+# Note! this script is not currently used. If it is, configuration needs to come from a location
+# other than LOCAL_CAS_UI_PATH, which is no longer required
+#
+
 # Override the properties we have in target with anything included in the .env file in the local UI repo
 override_ui_props_with_local_ui_props() {
   echo "==> Override the properties we have in .env.ui file with anything included in the .env file in the local UI repo"
@@ -32,7 +37,6 @@ override_ui_props_with_local_ui_props() {
   cp "$merged_env" "$target_env"
 
   # Clean up
-  rm -f "$merged_env.bak"
   rm "$merged_env"
 
   echo "Merged .env file created at $target_env"

--- a/bin/utils/resolve_secrets.sh
+++ b/bin/utils/resolve_secrets.sh
@@ -13,8 +13,6 @@ set -o pipefail
 # $3 kubernetes namespace
 # $4 kubernetes secret names (array)
 resolve_secrets() {
-  echo "==> Resolve Secrets"
-
   source="$1"
   shift
   target="$1"
@@ -23,7 +21,7 @@ resolve_secrets() {
   shift
   secretNames=("$@")
 
-  echo "Rendering template '$source' to '$target' in namespace '$k8s_namespace'"
+  echo "==> Resolving secrets in template '$source' to '$target' in namespace '$k8s_namespace'"
 
   # shellcheck disable=SC3020
   if ! command -v jq &> /dev/null
@@ -42,7 +40,7 @@ resolve_secrets() {
       # get value in format 'key=value' which can then be used with the 'export' command, setting them as env vars
       for secret in $(echo "$secrets" | jq -r "to_entries | map(\"\(.key)=\(.value|tostring)\") | .[]" ); do
         # shellcheck disable=SC2163
-        export "$secret"
+        export "$secret" || echo "Cannot export secret (see logged error above)"
       done
 
     done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+
   api:
     image: quay.io/hmpps/hmpps-approved-premises-api:latest
     container_name: ap-tools-api
@@ -32,15 +33,52 @@ services:
       - SERVICES_GOV-UK-BANK-HOLIDAYS-API_BASE-URL=http://ap-tools-wiremock:8080/gov-uk-bank-holidays-proxy
       - SERVICES_PRISONER-ALERTS-API_BASE-URL=http://ap-tools-wiremock:8080/prisoner-alerts-proxy
 
-  frontend:
+  # Only one of the following frontends is used, this is controlled by tilt via the tiltfile
+
+  cas1-ui:
     image: quay.io/hmpps/hmpps-approved-premises-ui:latest
-    container_name: ap-tools-ui
+    container_name: ap-tools-cas1-ui
     pull_policy: always
     depends_on:
       - redis
-      - api
     env_file:
-      - path: .env.ui
+      - path: .env.cas1-ui
+        format: raw
+    ports:
+      - "3000:3000"
+    environment:
+      - JAVA_TOOL_OPTIONS=-XX:UseSVE=0
+      - REDIS_HOST=ap-tools-redis
+      - APPROVED_PREMISES_API_URL=http://host.docker.internal:8080
+      - INGRESS_URL=http://localhost:3000
+    entrypoint: "node dist/server.js | bunyan"
+
+  cas2-ui:
+    image: quay.io/hmpps/hmpps-community-accommodation-tier-2-ui:latest
+    container_name: ap-tools-cas2-ui
+    pull_policy: always
+    depends_on:
+      - redis
+    env_file:
+      - path: .env.cas2-ui
+        format: raw
+    ports:
+      - "3000:3000"
+    environment:
+      - JAVA_TOOL_OPTIONS=-XX:UseSVE=0
+      - REDIS_HOST=ap-tools-redis
+      - APPROVED_PREMISES_API_URL=http://host.docker.internal:8080
+      - INGRESS_URL=http://localhost:3000
+    entrypoint: "node dist/server.js | bunyan"
+
+  cas3-ui:
+    image: quay.io/hmpps/hmpps-temporary-accommodation-ui:latest
+    container_name: ap-tools-cas3-ui
+    pull_policy: always
+    depends_on:
+      - redis
+    env_file:
+      - path: .env.cas3-ui
         format: raw
     ports:
       - "3000:3000"

--- a/tiltfile
+++ b/tiltfile
@@ -2,15 +2,19 @@ docker_compose("./docker-compose.yml")
 
 config.define_bool("local-api")
 config.define_bool("local-ui")
+config.define_bool("cas1")
+config.define_bool("cas2")
+config.define_bool("cas3")
 
 cfg = config.parse()
 
 local_api = cfg.get("local-api", False)
 local_ui = cfg.get("local-ui", False)
+cas1 = cfg.get("cas1", False)
+cas2 = cfg.get("cas2", False)
+cas3 = cfg.get("cas3", False)
 
 resources = [
-    "api",
-    "frontend",
     "wiremock",
     "postgres",
     "redis",
@@ -18,9 +22,9 @@ resources = [
 ]
 
 if local_api:
-    resources.remove("api")
+    print("Running local API")
     local_resource(
-        "local_api",
+        "api-local",
         serve_cmd="./gradlew bootRunDebug --stacktrace",
         # Note! These checks only wait for containers to start, ideally we'd wait for them to be ready
         # see https://docs.tilt.dev/resource_dependencies.html
@@ -34,25 +38,71 @@ if local_api:
             "BOOT_RUN_ENV_FILE": os.getcwd() + '/.env.api'
         }
     )
-    resources.append("local_api")
+    resources.append("api-local")
+else:
+    print("Running docker API")
+    resources.append("api")
 
-if local_ui:
-    resources.remove("frontend")
+if cas1:
+    if local_ui:
+        npm_command='export $(cat ' + os.getcwd() + '/.env.cas1-ui) && npm run start:dev'
 
-    npm_command='export $(cat ' + os.getcwd() + '/.env.ui) && npm run start:dev'
-
-    local_resource(
-        "local_ui",
-        cmd="npm install",
-        serve_cmd=npm_command,
-        serve_dir=os.getenv("LOCAL_CAS_UI_PATH"),
-        dir=os.getenv("LOCAL_CAS_UI_PATH"),
-        resource_deps=["redis"],
-        readiness_probe=probe(
-            period_secs=15, http_get=http_get_action(port=3000, path="/health")
+        local_resource(
+            "cas1-ui-local",
+            cmd="npm install",
+            serve_cmd=npm_command,
+            serve_dir=os.getenv("LOCAL_CAS1_UI_PATH"),
+            dir=os.getenv("LOCAL_CAS1_UI_PATH"),
+            resource_deps=["redis"],
+            readiness_probe=probe(
+                period_secs=15, http_get=http_get_action(port=3000, path="/health")
+            )
         )
-    )
-    resources.append("local_ui")
+        resources.append("cas1-ui-local")
+    else:
+        resources.append("cas1-ui")
+
+if cas2:
+    if local_ui:
+        npm_command='export $(cat ' + os.getcwd() + '/.env.cas2-ui) && npm run start:dev'
+
+        local_resource(
+            "cas2-ui-local",
+            cmd="npm install",
+            serve_cmd=npm_command,
+            serve_dir=os.getenv("LOCAL_CAS2_UI_PATH"),
+            dir=os.getenv("LOCAL_CAS2_UI_PATH"),
+            resource_deps=["redis"],
+            readiness_probe=probe(
+                period_secs=15, http_get=http_get_action(port=3000, path="/health")
+            )
+        )
+        resources.append("cas2-ui-local")
+    else:
+        resources.append("cas2-ui")
+
+if cas3:
+    if local_ui:
+        npm_command='export $(cat ' + os.getcwd() + '/.env.cas3-ui) && npm run start:dev'
+
+        local_resource(
+            "cas3-ui-local",
+            cmd="npm install",
+            serve_cmd=npm_command,
+            serve_dir=os.getenv("LOCAL_CAS3_UI_PATH"),
+            dir=os.getenv("LOCAL_CAS3_UI_PATH"),
+            resource_deps=["redis"],
+            readiness_probe=probe(
+                period_secs=15, http_get=http_get_action(port=3000, path="/health")
+            )
+        )
+        resources.append("cas3-ui-local")
+    else:
+        resources.append("cas3-ui")
 
 config.clear_enabled_resources()
+
+print("Loading resources...")
+print(resources)
+
 config.set_enabled_resources(resources)


### PR DESCRIPTION
Before this change when running a UI via docker the corresponding code must still be checked out and the `.env` file bootstrapped.

This commit fixes that issue by introducing a separate `.env.ui` file for each user interface, and adding a mandatory command line argument to indicate which UI is being used e.g.

```ap-tools server start --cas1```

This also fixed a bug that meant we weren’t actually stopping locally running UIs when running `ap-tools stop`. This is because we force killed the tilt process (`using killall -9`)