### PR TITLE
Add optional oasys overrides

### DIFF
--- a/wiremock/README.md
+++ b/wiremock/README.md
@@ -6,7 +6,7 @@ We can selectively mock a request by adding a mapping to the `mappings/overrides
 
 Example overrides are checked in with a priority set greater than 100 so they're ignored by default
 
-## Viewing Requests
+## Viewing Requests & Responses
 
 Wiremock provides an API to view requests:
 
@@ -14,4 +14,6 @@ Wiremock provides an API to view requests:
 
 Combine with jq to make it more usable:
 
-```curl http://localhost:9004/__admin/requests | jq '.requests[].request.url```
+```curl http://localhost:9004/__admin/requests | jq '.requests[].request.url'```
+
+Note that newest requests are shown at the top of the list

--- a/wiremock/mappings/overrides/README.md
+++ b/wiremock/mappings/overrides/README.md
@@ -1,0 +1,1 @@
+If you want to use an override in this directory, set its priority to less than 100 and restart wiremock via tilt

--- a/wiremock/mappings/overrides/ap-and-oasys-needs-details.json
+++ b/wiremock/mappings/overrides/ap-and-oasys-needs-details.json
@@ -1,0 +1,62 @@
+{
+  "priority": 101,
+  "id": "a5f0e36b-84a5-4169-92f3-3719cec200f4",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/ap-and-oasys-proxy/needs-details/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentId": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29Z",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "lastUpdatedDate": "2022-11-29T10:37:22Z",
+      "needs": {
+        "offenceAnalysisDetails": "Analysis",
+        "emotionalIssuesDetails": "[10.9] Mr Offender told me that he was untroubled by mental health difficulties and had no history of self harm or suicidal thoughts",
+        "drugIssuesDetails":  "[8.9] Mr Offender told me that he had experimented with many drugs throughout his teens. ...",
+        "alcoholIssuesDetails": "[9.9] Mr Offender told me that he rarely consumes alcohol and has not had any problems associated with excessive drinking in years...",
+        "lifestyleIssuesDetails":  "[7.9] Mr Offender has clearly had issues concerning the company he keeps, in that his involvement in the drug culture has at times been entrenched...",
+        "relationshipIssuesDetails": "[6.9] Mr Offender described his family as travellers.  He said that they were very supportive of him, although they had at times found it difficult to accept his involvement with drugs...",
+        "financeIssuesDetails":  "[5.9] Mr Offender was in receipt of Job Seekers Allowance prior to his current remand in custody...",
+        "educationTrainingEmploymentIssuesDetails": "[4.9] He said that he has since learnt to read and write during periods of custody and an initial assessment of his...",
+        "accommodationIssuesDetails":  "[3.9] Mr Offender told me that he was renting a room in a shared house, prior to his current remand...",
+        "attitudeIssuesDetails": "[12.9] During interview, Mr Offender referred to being motivated to alter his....",
+        "thinkingBehaviouralIssuesDetails":  "[11.9] The circumstances of the current offence suggest that Mr Offender acted ..."
+      },
+      "linksToHarm": {
+        "accommodationLinkedToHarm":  false,
+        "educationTrainingEmploymentLinkedToHarm": false,
+        "financeLinkedToHarm":  false,
+        "relationshipLinkedToHarm": false,
+        "lifestyleLinkedToHarm":  false,
+        "drugLinkedToHarm": false,
+        "alcoholLinkedToHarm":  false,
+        "emotionalLinkedToHarm": false,
+        "thinkingBehaviouralLinkedToHarm":  false,
+        "attitudeLinkedToHarm": false
+      },
+      "linksToReOffending": {
+        "accommodationLinkedToReOffending": true,
+        "educationTrainingEmploymentLinkedToReOffending":false,
+        "financeLinkedToReOffending": true,
+        "relationshipLinkedToReOffending":false,
+        "lifestyleLinkedToReOffending": true,
+        "drugLinkedToReOffending":false,
+        "alcoholLinkedToReOffending": true,
+        "emotionalLinkedToReOffending":false,
+        "thinkingBehaviouralLinkedToReOffending": true,
+        "attitudeLinkedToReOffending": false
+      }
+    }
+  }
+}

--- a/wiremock/mappings/overrides/ap-and-oasys-offence-details.json
+++ b/wiremock/mappings/overrides/ap-and-oasys-offence-details.json
@@ -1,0 +1,36 @@
+{
+  "priority": 101,
+  "id": "f5f0e36b-84a5-4169-92f3-3719cec200f4",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/ap-and-oasys-proxy/offence-details/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentId": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29Z",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "lastUpdatedDate": "2022-11-29T10:37:22Z",
+      "offence": {
+        "offenceAnalysis": "[2.1] Mr Offender appeared before Newcastle Crown Court 16/09/2021 where he pleaded guilty to Wounding and other acts endangering life...",
+        "othersInvolved": "[2.7.3] Mr Offender had some associates at his house at the time of the index offence, the total number is unknown...",
+        "issueContributingToRisk": "[2.98] The index offence is assessed as harm related and there is an identifiable victim Ms Ex Partner...",
+        "offenceMotivation": "[2.8.3] Mr Offender states that he was angry, and became aggressive towards Ms Ex Partner because...",
+        "victimImpact": "[2.5] Ms Ex Partner attended Newtree hospital at 22:40 hours on 01/03/21 with injuries to her face and body that they were...",
+        "victimPerpetratorRel": "[2.4.2] Ms Ex Partner, ex-partner of Mr Smith ",
+        "victimInfo": "[2.4.1] There is an element of vulnerability as Ms Ex Partner experience years of domestic abuse...",
+        "patternOffending": "[2.12] Mr Offender has 11 previous convictions from 22 offences. His criminal history includes...",
+        "acceptsResponsibility": "[2.11.t] Mr Offender states that he takes full responsibility for his actions and seems remorseful..."
+      }
+    }
+  }
+}

--- a/wiremock/mappings/overrides/ap-and-oasys-risk-management-plan.json
+++ b/wiremock/mappings/overrides/ap-and-oasys-risk-management-plan.json
@@ -1,0 +1,35 @@
+{
+  "priority": 101,
+  "id": "01794bde-9568-4795-b4d9-5e09105f3ba0",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/ap-and-oasys-proxy/risk-management-plan/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentId": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29Z",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "lastUpdatedDate": "2022-11-29T10:37:22Z",
+      "riskManagementPlan": {
+        "furtherConsiderations": "[RM28] Mr Offender is currently on remand awaiting sentence",
+        "additionalComments": "[RM35] Placeholder content for additional comments",
+        "contingencyPlans": "[RM34] Discuss any concerns with line manager/SPO Increase frequency of reporting Bring forward MAPPA/Consider Level 2 MAPPA professionals meetings  considered if MAPPA not applicable. Consider referral to Approved Premises Consider motivational interviewing/engagement officer.  Joint interview with police OM or other relevant agencies? To raise concerns Referral to substance misues worker for additional support. Warning letters to be employed Recall/Breach if risk not manageable.",
+        "victimSafetyPlanning": "[RM33] Undertake sentence planning with OS within 8 or 16 weeks of sentence carats - continue to work with Mr Smith and refer for relevant programmes during any prison sentence imposed. DIP supervise DRR is imposed or provide support post release if conditions/requirements to manage the specific risks.",
+        "interventionsAndTreatment": "[RM32] Requires referral to community drug DIP upon  release. To link in with employment/training resources such as College and ETEO. Completion of victim empathy module via 1-1 supervision to build upon awareness of impact of offending.   Level setting to be undertaken by Senior Probation Officer and OMU. Multi Agency Public Protection Panel to be convened if level 2 either at start of supervision or 6 months prior to release",
+        "monitoringAndControl": "[RM31] State they will have secure accommodation for Mr Offender  and partner on release, although she too is subject to a DRR at present. Supportive wider family.  Has completed previously Short Duration programme and attended one of the support sessions .  Engaged with CARATS in custody.  Complied with voluntary drug tests in custody. Some motivation to desist from alcohol/drug use in the future, this needs to be encouraged with use of community resources. Completed drug and heroin awareness programmes in custody.",
+        "supervision": "[RM30] Probation Officer, Education training and employment Officer, Prison Offender Supervisor",
+        "keyInformationAboutCurrentSituation": "[RM28.1] Currently on remand at HMP Wandsworth - Management of case under MAPPA - level not yet set."
+      }
+    }
+  }
+}

--- a/wiremock/mappings/overrides/ap-and-oasys-risk-to-the-individual.json
+++ b/wiremock/mappings/overrides/ap-and-oasys-risk-to-the-individual.json
@@ -1,0 +1,35 @@
+{
+  "priority": 101,
+  "id": "5bea7fae-090b-4010-b0bc-bf4d9068b2bd",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/ap-and-oasys-proxy/risk-to-the-individual/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentId": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29Z",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "lastUpdatedDate": "2022-11-29T10:37:22Z",
+      "riskToTheIndividual": {
+        "currentConcernsSelfHarmSuicide": "[R8.1.1] Review 06.10.21:\n\n        There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody.  In 2021...",
+        "previousConcernsSelfHarmSuicide": "[R8.1.4] Review 06.10.21:\n\n        There have been numerous ACCTs opened since 2013 and every subsequent year he has been in custody.  In 2021 there...",
+        "currentCustodyHostelCoping": "[R8.2.1] Has told prison staff that he swallowed batteries on one occasion due to wanting..",
+        "previousCustodyHostelCoping": "[R8.2.2] Reported in 2021 that he will keep himself to himself because he gets discomfiture...",
+        "currentVulnerability": "[R8.3.1] Review 06.10.21:\n\n        A previous assessor opined that Mr Smith was displaying all the characteristics of someone...",
+        "previousVulnerability": "[R8.3.2] This has not been noted previously, as my assessment identifies a different set of vulnerabilities.",
+        "riskOfSeriousHarm": "[R8.4.1] Mr Smith's previous risk of suicide does not indicate a risk of serious harm to others.",
+        "currentConcernsBreachOfTrustText": "[R9.3.1] Prison records highlight that previously a female contacted the prison to say she was receiving nuisance calls..."
+      }
+    }
+  }
+}

--- a/wiremock/mappings/overrides/ap-and-oasys-rosh-summary.json
+++ b/wiremock/mappings/overrides/ap-and-oasys-rosh-summary.json
@@ -1,0 +1,32 @@
+{
+  "priority": 101,
+  "id": "1112984a-9435-4a75-b0e1-30c6b4caf6d6",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/ap-and-oasys-proxy/rosh-summary/(.*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "assessmentId": 1310103,
+      "assessmentType": "LAYER3",
+      "dateCompleted": null,
+      "assessorSignedDate": null,
+      "initiationDate": "2022-11-02T15:17:29Z",
+      "assessmentStatus": "OPEN",
+      "superStatus": "WIP",
+      "limitedAccessOffender": false,
+      "lastUpdatedDate": "2022-11-29T10:37:22Z",
+      "roshSummary": {
+        "whoIsAtRisk": "[R10.1] IN CUSTODY\n\nKNOWN ADULTS:\nSuch as Ms Victim and any of the victims of the index offence if they are placed close to Mr Offender's cell.\n\nCHILDREN:\nOffener Jr.",
+        "natureOfRisk": "[R10.2] IN CUSTODY:\n\nKNOWN ADULTS:\nIntimidation, threats of violence, use of weapons or boiling water, physical education and violent assault, long term psychological impact as a result of Mr Offender violent behaviour. This harm may be cause in the course of physical altercation due to seeking revenge or holding grudges...",
+        "riskGreatest": "[R10.3] STATIC RISK FACTORS:\n\nMr Offender gender - At the time of the offence, Mr Offender was 35 years old and considered to be in the higher risk group.\n\nSTABLE DYNAMIC RISK FACTORS:\nThinking and behaviour - limited ability to manage mood or emotions poor impulse control. Mr Smith demonstrated cognitive deficit in committing the index offences and this still remains a concern...",
+        "riskIncreaseLikelyTo":  "[R10.4] CIRCUMSTANCES:\nA lack of stable accommodation\nunemployment\nnon constructive use of time\nbreakdown of family support\nbeing unable to access benefits\n\nUNDERLYING FACTORS:\npro criminal attitudes supporting commission of crime...",
+        "riskReductionLikelyTo": "[R10.5] Engage with Mental Health Services in prison and in the community.\nMaintain emotional stability.\nAbstain from alcohol.\nAbstain from illegal drugs.\nRegular testing for alcohol and drug use, in prison and on Licence.\nMaintain stable accommodation..."
+      }
+    }
+  }
+}

--- a/wiremock/mappings/overrides/hmpps-tier_get-tier-for-crn.json
+++ b/wiremock/mappings/overrides/hmpps-tier_get-tier-for-crn.json
@@ -1,5 +1,6 @@
 {
   "priority": 1000,
+  "id": "1212984a-9435-4a75-b0e1-30c6b4caf6d6",
   "request": {
     "method": "GET",
     "urlPathPattern": "/hmpps-tier-proxy/crn/(.*)/tier"


### PR DESCRIPTION
This commit adds some wiremock override files that can be optionally enabled to manually test oasys integration.

The content of these files are identical to those previously in the project because we started using upstream dev ap-and-oasys services, with some improvements to fake names