### PR TITLE
fix: added 1passwd to the brew file

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,3 @@
 brew "jq"
 brew "tilt"
+brew "1password-cli"


### PR DESCRIPTION
The scripts now require the `op` command to run, it's not in the brew file.