### PR TITLE
APS-2683: Match any method for case notes service proxy

### DIFF
--- a/wiremock/mappings/proxies/case-notes-proxy.json
+++ b/wiremock/mappings/proxies/case-notes-proxy.json
@@ -1,7 +1,7 @@
 {
   "priority": 100,
   "request": {
-    "method": "GET",
+    "method": "ANY",
     "urlPattern": "/case-notes-proxy/.*"
   },
   "response": {


### PR DESCRIPTION
The case notes endpoint is now using a POST method, so the proxy wiremock configuration should handle any HTTP verb to cover all use cases.