### PR TITLE
Disable wiremock proxying by default

### DIFF
--- a/.env.api.template
+++ b/.env.api.template
@@ -19,17 +19,31 @@ HMPPS_SQS_LOCALSTACKURL=http://localhost:4566
 HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK-SET-URI=https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json
 
-SERVICES_HMPPS-TIER_BASE-URL=http://localhost:9004/hmpps-tier-proxy
-SERVICES_PRISONS-API_BASE-URL=http://localhost:9004/prisons-api-proxy
-SERVICES_CASE-NOTES_BASE-URL=http://localhost:9004/case-notes-proxy
-SERVICES_AP-OASYS-CONTEXT-API_BASE-URL=http://localhost:9004/ap-and-oasys-proxy
-SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL=http://localhost:9004/ap-and-delius-proxy
-SERVICES_GOV-UK-BANK-HOLIDAYS-API_BASE-URL=http://localhost:9004/gov-uk-bank-holidays-proxy
-SERVICES_PRISONER-ALERTS-API_BASE-URL=http://localhost:9004/prisoner-alerts-proxy
-SERVICES_NOMIS-USER-ROLES-API_BASE-URL=http://localhost:9004/nomis-user-roles-proxy
-SERVICES_MANAGE-USERS-API_BASE-URL=http://localhost:9004/manage-users-proxy
-SERVICES_MANAGE-POM-CASES_BASE-URL=http://localhost:9004/manage-pom-cases-proxy
-SERVICES_PRISONER-SEARCH_BASE-URL=http://localhost:9004/prisoner-search-proxy
+# Call upstream endpoints directly
+SERVICES_AP-OASYS-CONTEXT-API_BASE-URL=https://approved-premises-and-oasys-dev.hmpps.service.justice.gov.uk
+SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL=https://approved-premises-and-delius-dev.hmpps.service.justice.gov.uk
+SERVICES_CASE-NOTES_BASE-URL=https://dev.offender-case-notes.service.justice.gov.uk
+SERVICES_GOV-UK-BANK-HOLIDAYS-API_BASE-URL=https://www.gov.uk
+SERVICES_HMPPS-TIER_BASE-URL=https://hmpps-tier-dev.hmpps.service.justice.gov.uk
+SERVICES_MANAGE-POM-CASES_BASE-URL=https://dev.moic.service.justice.gov.uk
+SERVICES_MANAGE-USERS-API_BASE-URL=https://manage-users-api-dev.hmpps.service.justice.gov.uk
+SERVICES_NOMIS-USER-ROLES-API_BASE-URL=https://nomis-user-roles-api-dev.prison.service.justice.gov.uk
+SERVICES_PRISONER-ALERTS-API_BASE-URL=https://alerts-api-dev.hmpps.service.justice.gov.uk
+SERVICES_PRISONER-SEARCH_BASE-URL=https://prisoner-search-dev.prison.service.justice.gov.uk
+SERVICES_PRISONS-API_BASE-URL=https://prison-api-dev.prison.service.justice.gov.uk
+
+# Call upstream endpoints via wiremock
+#SERVICES_AP-OASYS-CONTEXT-API_BASE-URL=http://localhost:9004/ap-and-oasys-proxy
+#SERVICES_AP-DELIUS-CONTEXT-API_BASE-URL=http://localhost:9004/ap-and-delius-proxy
+#SERVICES_CASE-NOTES_BASE-URL=http://localhost:9004/case-notes-proxy
+#SERVICES_GOV-UK-BANK-HOLIDAYS-API_BASE-URL=http://localhost:9004/gov-uk-bank-holidays-proxy
+#SERVICES_HMPPS-TIER_BASE-URL=http://localhost:9004/hmpps-tier-proxy
+#SERVICES_MANAGE-POM-CASES_BASE-URL=http://localhost:9004/manage-pom-cases-proxy
+#SERVICES_MANAGE-USERS-API_BASE-URL=http://localhost:9004/manage-users-proxy
+#SERVICES_NOMIS-USER-ROLES-API_BASE-URL=http://localhost:9004/nomis-user-roles-proxy
+#SERVICES_PRISONER-ALERTS-API_BASE-URL=http://localhost:9004/prisoner-alerts-proxy
+#SERVICES_PRISONER-SEARCH_BASE-URL=http://localhost:9004/prisoner-search-proxy
+#SERVICES_PRISONS-API_BASE-URL=http://localhost:9004/prisons-api-proxy
 
 SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_DELIUS-BACKED-APIS_CLIENT-ID=${SYSTEM_CLIENT_DELIUS_ID}
 SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_DELIUS-BACKED-APIS_CLIENT-SECRET=${SYSTEM_CLIENT_DELIUS_SECRET}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The tool manages local instances of the following:
 * CAS1, CAS2 or CAS3 UI - Either via docker or node (to run local code)
 * Postgres - Used by the API
 * Redis - Used by the UI and API
-* Wiremock - Proxies all requests to upstream services, allowing us to selectively mock responses
+* Wiremock - Can optionally be used as a proxy for all upstream requests, allowing us to selectively mock responses
 * Localstack - Provides SQS for the API
 
 All other upstream services (e.g. hmpps-auth, prisoner api etc.) are provided by the [Cloud Platform's](https://user-guide.cloud-platform.service.justice.gov.uk/) 'Dev' environment
@@ -83,7 +83,7 @@ A [sync-secrets.sh](bin/sync-secrets.sh) script is provided to sync secrets from
 
 ## Wiremock
 
-All requests to upstream services are proxied by wiremock. Mocks can be configured for specific requests. For more information, [click here](./wiremock/README.md)
+By default, Wiremock is not used as it can have some performance impacts. It can be configured as a middle man between the API and upstream services, allowing requests to be selectively mocked. For more information, [click here](./wiremock/README.md)
 
 ## Known Limitations
 

--- a/wiremock/README.md
+++ b/wiremock/README.md
@@ -1,14 +1,18 @@
 # Overview
 
-All upstream requests (excluding auth) are proxied via wiremock.
+By default, Wiremock is not used as it can have some performance impacts.
 
-We can selectively mock a request by adding a mapping to the `mappings/overrides` folder with a priority < 100
+It can be configured as a middle man between the API and upstream services, allowing requests to be selectively mocked.
+
+To enable request proxying via wiremock update `.env.api.template`, commenting out all configuration in the section labeled '# Call upstream endpoints directly' and uncommenting all configuration in the section labeled '# Call upstream endpoints via wiremock'
+
+We can then selectively mock a request by adding a mapping to the `mappings/overrides` folder with a priority < 100
 
 Example overrides are checked in with a priority set greater than 100 so they're ignored by default
 
 ## Viewing Requests & Responses
 
-Wiremock provides an API to view requests:
+If wiremock is used as a proxy we can use its API to view all upstream requests:
 
 ```curl http://localhost:9004/__admin/requests```
 


### PR DESCRIPTION
We’ve found that use of wiremock to proxy upstream requests is leading to significant response delays. We’ve only started to observe this recently, suggesting that the issue isn’t directly to wiremock.

Until we can determine the root cause of the issue we will disable use of Wiremock by default.

This commit disables wiremock and provides instructions on how it can be enabled if required.