### PR TITLE
Added CAS2 bail to AP_REPOS in sync-secrets

### DIFF
--- a/bin/sync-secrets.sh
+++ b/bin/sync-secrets.sh
@@ -45,6 +45,7 @@ ONEPASS_TAG=cas_managed
 readonly AP_REPOS=(
   "hmpps-approved-premises-ui"
   "hmpps-approved-premises-api"
+  "hmpps-community-accommodation-tier-2-bail-ui"
 )
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
Added CAS2 bail to AP_REPOS in `bin/sync-secrets.sh` so we can use AP users in CAS2 new cohort E2E tests

`bin/sync-secrets.sh` has been successfully run with these changes